### PR TITLE
Add Helm chart for SUS platform deployment

### DIFF
--- a/charts/sus/.helmignore
+++ b/charts/sus/.helmignore
@@ -1,0 +1,13 @@
+.DS_Store
+.git
+.gitignore
+.bzr
+.bzrignore
+.hg
+.hgignore
+.svn
+*.swp
+*.bak
+*.tmp
+*.orig
+*~

--- a/charts/sus/Chart.yaml
+++ b/charts/sus/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: sus
+description: SUS (Single Use Software) — a self-hosted platform for building and running disposable apps with Claude Code
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - sus
+  - claude-code
+  - single-use-software
+home: https://github.com/alastairdrong/sus

--- a/charts/sus/templates/NOTES.txt
+++ b/charts/sus/templates/NOTES.txt
@@ -1,0 +1,13 @@
+SUS has been installed.
+
+Namespaces created:
+  - {{ .Values.namespaces.platform }} (control plane)
+  - {{ .Values.namespaces.workloads }} (build and run pods)
+
+Landing page service:
+  {{ include "sus.fullname" . }}-landing.{{ .Values.namespaces.platform }}.svc.cluster.local:{{ .Values.service.port }}
+
+To access the landing page locally, run:
+  kubectl port-forward -n {{ .Values.namespaces.platform }} svc/{{ include "sus.fullname" . }}-landing {{ .Values.service.port }}:{{ .Values.service.port }}
+
+Then open http://localhost:{{ .Values.service.port }} in your browser.

--- a/charts/sus/templates/_helpers.tpl
+++ b/charts/sus/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "sus.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label value.
+*/}}
+{{- define "sus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "sus.labels" -}}
+helm.sh/chart: {{ include "sus.chart" . }}
+{{ include "sus.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "sus.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/sus/templates/deployment.yaml
+++ b/charts/sus/templates/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sus.fullname" . }}-landing
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "sus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: landing
+spec:
+  replicas: {{ .Values.landing.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "sus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: landing
+  template:
+    metadata:
+      labels:
+        {{- include "sus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: landing
+    spec:
+      serviceAccountName: {{ .Values.landing.serviceAccount.name }}
+      containers:
+        - name: landing
+          image: "{{ .Values.landing.image.repository }}:{{ .Values.landing.image.tag }}"
+          imagePullPolicy: {{ .Values.landing.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.landing.port }}
+              protocol: TCP
+          env:
+            - name: SUS_WORKLOADS_NAMESPACE
+              value: {{ .Values.namespaces.workloads | quote }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.landing.resources | nindent 12 }}

--- a/charts/sus/templates/namespaces.yaml
+++ b/charts/sus/templates/namespaces.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "sus.labels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespaces.workloads }}
+  labels:
+    {{- include "sus.labels" . | nindent 4 }}

--- a/charts/sus/templates/rbac.yaml
+++ b/charts/sus/templates/rbac.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.rbac.roleName }}
+  namespace: {{ .Values.namespaces.workloads }}
+  labels:
+    {{- include "sus.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.rbac.roleBindingName }}
+  namespace: {{ .Values.namespaces.workloads }}
+  labels:
+    {{- include "sus.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.landing.serviceAccount.name }}
+    namespace: {{ .Values.namespaces.platform }}
+roleRef:
+  kind: Role
+  name: {{ .Values.rbac.roleName }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/sus/templates/service.yaml
+++ b/charts/sus/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sus.fullname" . }}-landing
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "sus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: landing
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: landing

--- a/charts/sus/templates/serviceaccount.yaml
+++ b/charts/sus/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.landing.serviceAccount.name }}
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "sus.labels" . | nindent 4 }}

--- a/charts/sus/values.yaml
+++ b/charts/sus/values.yaml
@@ -1,0 +1,35 @@
+# -- Namespace configuration
+namespaces:
+  # -- Namespace for the SUS control plane (landing page pod)
+  platform: sus
+  # -- Namespace for build and run workload pods
+  workloads: sus-workloads
+
+# -- Landing page deployment configuration
+landing:
+  image:
+    repository: localhost:5000/sus-landing
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  port: 8000
+  serviceAccount:
+    name: sus-landing
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# -- Service configuration for the landing page
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8000
+
+# -- RBAC role name for pod management in the workloads namespace
+rbac:
+  roleName: sus-pod-manager
+  roleBindingName: sus-landing-binding


### PR DESCRIPTION
## Summary
- Helm chart at `charts/sus/` for bootstrapping the SUS platform on Kubernetes
- Namespace templates for `sus` (platform) and `sus-workloads` (build/run pods)
- ServiceAccount, Role, and RoleBinding for landing page pod to manage workload pods
- Deployment and Service templates for the landing page pod
- Configurable `values.yaml` with sensible homelab defaults

## Test plan
- [ ] `helm template sus ./charts/sus` renders valid manifests
- [ ] `helm lint ./charts/sus` passes
- [ ] Verify RBAC grants correct permissions (pods, pods/log, services in sus-workloads)
- [ ] Verify ServiceAccount is cross-namespace bound correctly

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)