### PR TITLE
Add k3d dev environment and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+CLUSTER_NAME := sus
+REGISTRY := localhost:5000
+LANDING_IMAGE := $(REGISTRY)/sus-landing
+TAG := dev
+
+.PHONY: help cluster-up cluster-down build push deploy upgrade dev teardown status logs
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+# --- Cluster lifecycle ---
+
+cluster-up: ## Create k3d cluster with local registry
+	k3d cluster create --config k3d.yaml
+	@echo "Waiting for cluster to be ready..."
+	kubectl wait --for=condition=Ready nodes --all --timeout=60s
+	@echo "Cluster '$(CLUSTER_NAME)' is ready."
+
+cluster-down: ## Delete k3d cluster
+	k3d cluster delete $(CLUSTER_NAME)
+
+# --- Build and push ---
+
+build: ## Build the landing page container image
+	docker build -t $(LANDING_IMAGE):$(TAG) ./landing
+
+push: ## Push the landing page image to the local registry
+	docker push $(LANDING_IMAGE):$(TAG)
+
+# --- Deploy ---
+
+deploy: ## Install the Helm chart into the cluster
+	helm install sus ./charts/sus \
+		--set landing.image.repository=$(LANDING_IMAGE) \
+		--set landing.image.tag=$(TAG)
+
+upgrade: ## Upgrade the Helm release with latest values
+	helm upgrade sus ./charts/sus \
+		--set landing.image.repository=$(LANDING_IMAGE) \
+		--set landing.image.tag=$(TAG)
+
+# --- Compound targets ---
+
+dev: cluster-up build push deploy ## Full dev setup: cluster + build + deploy
+	@echo ""
+	@echo "SUS is running. Access the landing page:"
+	@echo "  kubectl port-forward -n sus svc/sus-landing 8080:80"
+	@echo ""
+
+teardown: cluster-down ## Tear down everything
+
+# --- Helpers ---
+
+status: ## Show cluster and pod status
+	@echo "=== Nodes ==="
+	@kubectl get nodes
+	@echo ""
+	@echo "=== Pods (sus) ==="
+	@kubectl get pods -n sus
+	@echo ""
+	@echo "=== Pods (sus-workloads) ==="
+	@kubectl get pods -n sus-workloads
+	@echo ""
+	@echo "=== Services (sus) ==="
+	@kubectl get svc -n sus
+
+logs: ## Tail landing page pod logs
+	kubectl logs -n sus -l app.kubernetes.io/component=landing -f
+
+redeploy: build push upgrade ## Rebuild image and upgrade the deployment
+	kubectl rollout restart deployment -n sus -l app.kubernetes.io/component=landing

--- a/charts/sus/templates/deployment.yaml
+++ b/charts/sus/templates/deployment.yaml
@@ -32,13 +32,13 @@ spec:
               value: {{ .Values.namespaces.workloads | quote }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: http
             initialDelaySeconds: 3
             periodSeconds: 5

--- a/k3d.yaml
+++ b/k3d.yaml
@@ -1,0 +1,15 @@
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: sus
+servers: 1
+agents: 2
+registries:
+  create:
+    name: sus-registry
+    host: "0.0.0.0"
+    hostPort: "5000"
+ports:
+  - port: 8080:80
+    nodeFilters:
+      - loadbalancer


### PR DESCRIPTION
## Summary
- `k3d.yaml` cluster config: 1 server + 2 agents with local registry at `localhost:5000`
- `Makefile` with full dev lifecycle targets:
  - `make dev` — one-command setup (cluster + build + deploy)
  - `make redeploy` — rebuild and upgrade
  - `make teardown` — clean everything up
  - `make status` / `make logs` — observe the running stack
- Fix health probe paths in Helm chart deployment (`/health` → `/healthz` and `/readyz`)

## Prerequisites
Docker, k3d, kubectl, Helm

## Test plan
- [ ] `make cluster-up` creates a 3-node k3d cluster with registry
- [ ] `make build && make push` builds and pushes the landing page image
- [ ] `make deploy` installs the Helm chart and pods come up healthy
- [ ] `make status` shows running pods in both namespaces
- [ ] `make teardown` cleans up the cluster

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)