### PR TITLE
Add build pod lifecycle management and session store

### DIFF
--- a/landing/app/pods.py
+++ b/landing/app/pods.py
@@ -1,0 +1,170 @@
+"""Build pod lifecycle manager — create, monitor, and tear down build pods."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import datetime, timezone
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+
+class BuildPodManager:
+    """Wraps the Kubernetes Python client to manage build pods."""
+
+    def __init__(self) -> None:
+        # Load cluster config (in-cluster first, fallback to kubeconfig for local dev)
+        try:
+            config.load_incluster_config()
+        except config.ConfigException:
+            config.load_kube_config()
+
+        self._core = client.CoreV1Api()
+        self._namespace = os.environ.get("SUS_WORKLOADS_NAMESPACE", "sus-workloads")
+        self._image = os.environ.get("SUS_BUILD_IMAGE", "localhost:5000/sus-build:dev")
+
+        # Resource defaults (overridable via env)
+        self._cpu_request = os.environ.get("SUS_BUILD_CPU_REQUEST", "250m")
+        self._cpu_limit = os.environ.get("SUS_BUILD_CPU_LIMIT", "1")
+        self._mem_request = os.environ.get("SUS_BUILD_MEM_REQUEST", "256Mi")
+        self._mem_limit = os.environ.get("SUS_BUILD_MEM_LIMIT", "512Mi")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _short_hash(user_id: str, app_slug: str) -> str:
+        """Return an 8-char hex hash for pod-name uniqueness."""
+        digest = hashlib.sha256(f"{user_id}:{app_slug}:{datetime.now(timezone.utc).isoformat()}".encode())
+        return digest.hexdigest()[:8]
+
+    def _pod_manifest(
+        self,
+        name: str,
+        user_id: str,
+        app_slug: str,
+        branch: str,
+    ) -> client.V1Pod:
+        return client.V1Pod(
+            metadata=client.V1ObjectMeta(
+                name=name,
+                namespace=self._namespace,
+                labels={
+                    "app.kubernetes.io/component": "build",
+                    "sus.dev/user": user_id,
+                    "sus.dev/app": app_slug,
+                },
+                annotations={
+                    "sus.dev/last-seen": datetime.now(timezone.utc).isoformat(),
+                },
+            ),
+            spec=client.V1PodSpec(
+                restart_policy="Never",
+                containers=[
+                    client.V1Container(
+                        name="build",
+                        image=self._image,
+                        ports=[
+                            client.V1ContainerPort(container_port=8080, name="terminal"),
+                            client.V1ContainerPort(container_port=3000, name="preview"),
+                        ],
+                        env=[
+                            client.V1EnvVar(name="GIT_BRANCH", value=branch),
+                            client.V1EnvVar(name="GIT_REPO_URL", value=f"https://github.com/sus/{app_slug}.git"),
+                            client.V1EnvVar(name="USER_ID", value=user_id),
+                            client.V1EnvVar(name="APP_SLUG", value=app_slug),
+                        ],
+                        resources=client.V1ResourceRequirements(
+                            requests={"cpu": self._cpu_request, "memory": self._mem_request},
+                            limits={"cpu": self._cpu_limit, "memory": self._mem_limit},
+                        ),
+                    )
+                ],
+            ),
+        )
+
+    @staticmethod
+    def _pod_to_dict(pod: client.V1Pod) -> dict:
+        """Extract useful status info from a V1Pod object."""
+        return {
+            "name": pod.metadata.name,
+            "phase": pod.status.phase if pod.status else None,
+            "pod_ip": pod.status.pod_ip if pod.status else None,
+            "ports": {
+                "terminal": 8080,
+                "preview": 3000,
+            },
+            "labels": pod.metadata.labels or {},
+            "annotations": pod.metadata.annotations or {},
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def create_build_pod(self, user_id: str, app_slug: str, branch: str) -> str:
+        """Create a build pod and return its name."""
+        short = self._short_hash(user_id, app_slug)
+        name = f"build-{user_id}-{short}"
+        manifest = self._pod_manifest(name, user_id, app_slug, branch)
+        self._core.create_namespaced_pod(namespace=self._namespace, body=manifest)
+        return name
+
+    def delete_build_pod(self, pod_name: str) -> None:
+        """Delete a build pod by name."""
+        try:
+            self._core.delete_namespaced_pod(
+                name=pod_name,
+                namespace=self._namespace,
+                body=client.V1DeleteOptions(grace_period_seconds=0),
+            )
+        except ApiException as exc:
+            if exc.status != 404:
+                raise
+
+    def get_build_pod(self, pod_name: str) -> dict | None:
+        """Return pod status info or None if not found."""
+        try:
+            pod = self._core.read_namespaced_pod(name=pod_name, namespace=self._namespace)
+            return self._pod_to_dict(pod)
+        except ApiException as exc:
+            if exc.status == 404:
+                return None
+            raise
+
+    def list_build_pods(self, user_id: str | None = None) -> list[dict]:
+        """List build pods, optionally filtered by user."""
+        label_selector = "app.kubernetes.io/component=build"
+        if user_id:
+            label_selector += f",sus.dev/user={user_id}"
+
+        pods = self._core.list_namespaced_pod(
+            namespace=self._namespace,
+            label_selector=label_selector,
+        )
+        return [self._pod_to_dict(p) for p in pods.items]
+
+    def heartbeat(self, pod_name: str) -> None:
+        """Update the last-seen annotation on the pod."""
+        now = datetime.now(timezone.utc).isoformat()
+        body = {"metadata": {"annotations": {"sus.dev/last-seen": now}}}
+        self._core.patch_namespaced_pod(name=pod_name, namespace=self._namespace, body=body)
+
+    def cleanup_idle_pods(self, timeout_minutes: int = 10) -> list[str]:
+        """Delete pods whose last heartbeat is older than *timeout_minutes*. Returns deleted names."""
+        now = datetime.now(timezone.utc)
+        deleted: list[str] = []
+
+        for pod_info in self.list_build_pods():
+            last_seen_raw = pod_info["annotations"].get("sus.dev/last-seen")
+            if not last_seen_raw:
+                continue
+            last_seen = datetime.fromisoformat(last_seen_raw)
+            elapsed = (now - last_seen).total_seconds() / 60
+            if elapsed > timeout_minutes:
+                self.delete_build_pod(pod_info["name"])
+                deleted.append(pod_info["name"])
+
+        return deleted

--- a/landing/app/sessions.py
+++ b/landing/app/sessions.py
@@ -1,0 +1,101 @@
+"""SQLite-backed session store for build pod sessions."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+
+
+class SessionStore:
+    """Manages a lightweight SQLite database that tracks active build sessions."""
+
+    def __init__(self, db_path: str = "sessions.db") -> None:
+        self._db_path = db_path
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._create_table()
+
+    def _create_table(self) -> None:
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                user_id   TEXT NOT NULL,
+                app_slug  TEXT NOT NULL,
+                pod_name  TEXT NOT NULL,
+                branch    TEXT NOT NULL,
+                last_seen TEXT NOT NULL,
+                PRIMARY KEY (user_id, app_slug)
+            )
+            """
+        )
+        self._conn.commit()
+
+    @staticmethod
+    def _row_to_dict(row: sqlite3.Row | None) -> dict | None:
+        if row is None:
+            return None
+        return dict(row)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def upsert(self, user_id: str, pod_name: str, branch: str, app_slug: str) -> None:
+        """Insert or replace a session record."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            """
+            INSERT INTO sessions (user_id, pod_name, branch, app_slug, last_seen)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT (user_id, app_slug) DO UPDATE SET
+                pod_name  = excluded.pod_name,
+                branch    = excluded.branch,
+                last_seen = excluded.last_seen
+            """,
+            (user_id, pod_name, branch, app_slug, now),
+        )
+        self._conn.commit()
+
+    def get(self, user_id: str, app_slug: str) -> dict | None:
+        """Fetch a single session by user and app."""
+        row = self._conn.execute(
+            "SELECT * FROM sessions WHERE user_id = ? AND app_slug = ?",
+            (user_id, app_slug),
+        ).fetchone()
+        return self._row_to_dict(row)
+
+    def get_by_pod(self, pod_name: str) -> dict | None:
+        """Fetch a session by pod name."""
+        row = self._conn.execute(
+            "SELECT * FROM sessions WHERE pod_name = ?",
+            (pod_name,),
+        ).fetchone()
+        return self._row_to_dict(row)
+
+    def update_last_seen(self, pod_name: str) -> None:
+        """Touch the last_seen timestamp for a given pod."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            "UPDATE sessions SET last_seen = ? WHERE pod_name = ?",
+            (now, pod_name),
+        )
+        self._conn.commit()
+
+    def delete(self, user_id: str, app_slug: str) -> None:
+        """Remove a session record."""
+        self._conn.execute(
+            "DELETE FROM sessions WHERE user_id = ? AND app_slug = ?",
+            (user_id, app_slug),
+        )
+        self._conn.commit()
+
+    def list_sessions(self, user_id: str | None = None) -> list[dict]:
+        """List sessions, optionally filtered by user."""
+        if user_id:
+            rows = self._conn.execute(
+                "SELECT * FROM sessions WHERE user_id = ?", (user_id,)
+            ).fetchall()
+        else:
+            rows = self._conn.execute("SELECT * FROM sessions").fetchall()
+        return [dict(r) for r in rows]

--- a/landing/requirements.txt
+++ b/landing/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 kubernetes
 websockets
 jinja2
+aiosqlite


### PR DESCRIPTION
## Summary
- `landing/app/pods.py` — `BuildPodManager` class wrapping the Kubernetes Python client:
  - Create/delete/get/list build pods in `sus-workloads` namespace
  - Heartbeat via pod annotation (`sus.dev/last-seen`)
  - Idle pod cleanup (configurable timeout, default 10 min)
  - In-cluster config with kubeconfig fallback for local dev
- `landing/app/sessions.py` — `SessionStore` class backed by SQLite:
  - Tracks user → pod + branch mappings
  - Upsert, get, delete, list operations
- Added `aiosqlite` dependency

## Test plan
- [ ] `BuildPodManager` creates pods with correct labels, annotations, and env vars
- [ ] `heartbeat()` updates the `sus.dev/last-seen` annotation
- [ ] `cleanup_idle_pods()` deletes pods past the timeout threshold
- [ ] `SessionStore` correctly persists and retrieves session data
- [ ] Fallback to kubeconfig works for local development

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)