### PR TITLE
Add run pod lifecycle, publisher, and run mode UI

### DIFF
--- a/landing/app/git_workflow.py
+++ b/landing/app/git_workflow.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime, timezone
 
 from .pods import BuildPodManager
+from .publisher import Publisher
 from .sessions import SessionStore
 
 logger = logging.getLogger(__name__)
@@ -22,9 +23,11 @@ class GitWorkflowManager:
         self,
         pod_manager: BuildPodManager,
         session_store: SessionStore,
+        publisher: Publisher | None = None,
     ) -> None:
         self._pods = pod_manager
         self._sessions = session_store
+        self._publisher = publisher
 
     # ------------------------------------------------------------------
     # Helpers
@@ -151,7 +154,21 @@ class GitWorkflowManager:
             app_slug,
             branch,
         )
-        return {"status": "publish_requested", "branch": branch}
+
+        # If a publisher is configured, also create/update the run pod.
+        publish_result = None
+        if self._publisher is not None:
+            try:
+                publish_result = self._publisher.publish_app(team=team, app_slug=app_slug)
+                logger.info("Run pod published: %s", publish_result)
+            except Exception:
+                logger.exception("Failed to publish run pod for %s/%s", team, app_slug)
+
+        return {
+            "status": "publish_requested",
+            "branch": branch,
+            "publish": publish_result,
+        }
 
     def end_session(self, user_id: str, team: str, app_slug: str) -> None:
         """Tear down the build pod and remove the session record."""

--- a/landing/app/main.py
+++ b/landing/app/main.py
@@ -12,6 +12,7 @@ from fastapi.templating import Jinja2Templates
 from .catalog import scan_apps
 from .identity import IdentityProvider, SingleUserProvider, UserIdentity
 from .routes.build import router as build_router
+from .routes.run import router as run_router
 
 # ---------------------------------------------------------------------------
 # Application & templates
@@ -19,6 +20,7 @@ from .routes.build import router as build_router
 
 app = FastAPI(title="SUS Landing Page", version="0.1.0")
 app.include_router(build_router)
+app.include_router(run_router)
 
 _templates_dir = Path(__file__).resolve().parent / "templates"
 templates = Jinja2Templates(directory=str(_templates_dir))

--- a/landing/app/publisher.py
+++ b/landing/app/publisher.py
@@ -1,0 +1,58 @@
+"""Publish flow manager — builds images and creates run pods for published apps."""
+
+from __future__ import annotations
+
+import logging
+
+from .run_pods import RunPodManager
+
+logger = logging.getLogger(__name__)
+
+
+class Publisher:
+    """Coordinates the publish flow: image naming, run pod rolling updates."""
+
+    def __init__(self, run_pod_manager: RunPodManager) -> None:
+        self._run_pods = run_pod_manager
+
+    @staticmethod
+    def get_app_image(team: str, app_slug: str) -> str:
+        """Return the expected container image name for an app."""
+        return f"localhost:5000/sus-app-{team}-{app_slug}:latest"
+
+    def publish_app(self, team: str, app_slug: str) -> dict:
+        """Execute the publish flow for an app.
+
+        1. Determine the image name.
+        2. Tear down any existing run pod (rolling update).
+        3. Create a new run pod with the published image.
+
+        Returns a dict with status, pod name, and image.
+        """
+        image = self.get_app_image(team, app_slug)
+
+        # TODO: Trigger the actual container image build and push here.
+        # For now we assume the image was already built and pushed to the
+        # local registry (e.g. by a CI job or the build pod's publish step).
+        logger.info("Publishing %s/%s with image %s", team, app_slug, image)
+
+        # Rolling update — tear down the old run pod if one exists.
+        existing = self._run_pods.find_run_pod(team, app_slug)
+        if existing:
+            logger.info(
+                "Deleting existing run pod %s for rolling update", existing["name"]
+            )
+            self._run_pods.delete_run_pod(existing["name"])
+
+        # Create the new run pod.
+        pod_info = self._run_pods.create_run_pod(
+            team=team, app_slug=app_slug, image=image
+        )
+
+        logger.info("Published %s/%s — run pod %s", team, app_slug, pod_info["name"])
+
+        return {
+            "status": "published",
+            "pod_name": pod_info["name"],
+            "image": image,
+        }

--- a/landing/app/routes/run.py
+++ b/landing/app/routes/run.py
@@ -1,0 +1,95 @@
+"""Run-mode routes — serve published apps via proxied run pods."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, Response
+from fastapi.templating import Jinja2Templates
+
+from ..proxy import http_proxy
+from ..run_pods import RunPodManager
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/run")
+
+_templates_dir = Path(__file__).resolve().parent.parent / "templates"
+_templates = Jinja2Templates(directory=str(_templates_dir))
+
+# ---------------------------------------------------------------------------
+# Lazy-initialised singleton
+# ---------------------------------------------------------------------------
+
+_run_pod_mgr: Optional[RunPodManager] = None
+
+
+def _get_run_pod_mgr() -> RunPodManager:
+    """Return the RunPodManager, creating it on first call."""
+    global _run_pod_mgr  # noqa: PLW0603
+    if _run_pod_mgr is None:
+        _run_pod_mgr = RunPodManager()
+    return _run_pod_mgr
+
+
+# ---------------------------------------------------------------------------
+# Run UI
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{team}/{app_slug}", response_class=HTMLResponse)
+async def run_ui(
+    request: Request,
+    team: str,
+    app_slug: str,
+) -> HTMLResponse:
+    """Render the run-mode page with the app in a full-page iframe."""
+    return _templates.TemplateResponse(
+        "run.html",
+        {
+            "request": request,
+            "team": team,
+            "app_slug": app_slug,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTTP proxy — run pod app traffic
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{team}/{app_slug}/proxy/{path:path}")
+async def run_proxy(
+    request: Request,
+    team: str,
+    app_slug: str,
+    path: str,
+) -> Response:
+    """Proxy HTTP requests to the run pod's app server.
+
+    Looks up the run pod by team/app labels and forwards traffic to port 3000.
+    Returns 503 if no run pod is available.
+    """
+    try:
+        mgr = _get_run_pod_mgr()
+        pod_info = mgr.find_run_pod(team, app_slug)
+    except Exception:
+        logger.exception("Failed to look up run pod for %s/%s", team, app_slug)
+        return Response(content="Service Unavailable", status_code=503)
+
+    if pod_info is None or not pod_info.get("pod_ip"):
+        return Response(
+            content="No run pod available for this application.",
+            status_code=503,
+        )
+
+    return await http_proxy(
+        request,
+        pod_ip=pod_info["pod_ip"],
+        pod_port=3000,
+        path=f"/{path}" if path else "/",
+    )

--- a/landing/app/run_pods.py
+++ b/landing/app/run_pods.py
@@ -1,0 +1,164 @@
+"""Run pod lifecycle manager — create, monitor, and tear down run pods."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import datetime, timezone
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+
+class RunPodManager:
+    """Wraps the Kubernetes Python client to manage run pods.
+
+    Run pods serve published applications in read-only mode — no Claude
+    session, no editing.  They are lighter-weight than build pods.
+    """
+
+    def __init__(self) -> None:
+        # Load cluster config (in-cluster first, fallback to kubeconfig for local dev)
+        try:
+            config.load_incluster_config()
+        except config.ConfigException:
+            config.load_kube_config()
+
+        self._core = client.CoreV1Api()
+        self._namespace = os.environ.get("SUS_WORKLOADS_NAMESPACE", "sus-workloads")
+
+        # Resource defaults — lighter than build pods
+        self._cpu_request = os.environ.get("SUS_RUN_CPU_REQUEST", "100m")
+        self._cpu_limit = os.environ.get("SUS_RUN_CPU_LIMIT", "500m")
+        self._mem_request = os.environ.get("SUS_RUN_MEM_REQUEST", "128Mi")
+        self._mem_limit = os.environ.get("SUS_RUN_MEM_LIMIT", "256Mi")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _short_hash(team: str, app_slug: str) -> str:
+        """Return an 8-char hex hash for pod-name uniqueness."""
+        digest = hashlib.sha256(
+            f"{team}:{app_slug}:{datetime.now(timezone.utc).isoformat()}".encode()
+        )
+        return digest.hexdigest()[:8]
+
+    def _pod_manifest(
+        self,
+        name: str,
+        team: str,
+        app_slug: str,
+        image: str,
+    ) -> client.V1Pod:
+        return client.V1Pod(
+            metadata=client.V1ObjectMeta(
+                name=name,
+                namespace=self._namespace,
+                labels={
+                    "app.kubernetes.io/component": "run",
+                    "sus.dev/team": team,
+                    "sus.dev/app": app_slug,
+                },
+            ),
+            spec=client.V1PodSpec(
+                restart_policy="Always",
+                containers=[
+                    client.V1Container(
+                        name="app",
+                        image=image,
+                        ports=[
+                            client.V1ContainerPort(container_port=3000, name="http"),
+                        ],
+                        resources=client.V1ResourceRequirements(
+                            requests={
+                                "cpu": self._cpu_request,
+                                "memory": self._mem_request,
+                            },
+                            limits={
+                                "cpu": self._cpu_limit,
+                                "memory": self._mem_limit,
+                            },
+                        ),
+                        security_context=client.V1SecurityContext(
+                            read_only_root_filesystem=True,
+                        ),
+                    )
+                ],
+            ),
+        )
+
+    @staticmethod
+    def _pod_to_dict(pod: client.V1Pod) -> dict:
+        """Extract useful status info from a V1Pod object."""
+        return {
+            "name": pod.metadata.name,
+            "phase": pod.status.phase if pod.status else None,
+            "pod_ip": pod.status.pod_ip if pod.status else None,
+            "ports": {"http": 3000},
+            "labels": pod.metadata.labels or {},
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def create_run_pod(self, team: str, app_slug: str, image: str) -> dict:
+        """Create a run pod and return its status info."""
+        short = self._short_hash(team, app_slug)
+        name = f"run-{team}-{app_slug}-{short}"
+        manifest = self._pod_manifest(name, team, app_slug, image)
+        pod = self._core.create_namespaced_pod(
+            namespace=self._namespace, body=manifest
+        )
+        return self._pod_to_dict(pod)
+
+    def get_run_pod(self, pod_name: str) -> dict | None:
+        """Return pod status info or None if not found."""
+        try:
+            pod = self._core.read_namespaced_pod(
+                name=pod_name, namespace=self._namespace
+            )
+            return self._pod_to_dict(pod)
+        except ApiException as exc:
+            if exc.status == 404:
+                return None
+            raise
+
+    def find_run_pod(self, team: str, app_slug: str) -> dict | None:
+        """Find an existing run pod for this app by label selector."""
+        label_selector = (
+            f"app.kubernetes.io/component=run,"
+            f"sus.dev/team={team},"
+            f"sus.dev/app={app_slug}"
+        )
+        pods = self._core.list_namespaced_pod(
+            namespace=self._namespace,
+            label_selector=label_selector,
+        )
+        if not pods.items:
+            return None
+        # Return the first match (there should be at most one).
+        return self._pod_to_dict(pods.items[0])
+
+    def delete_run_pod(self, pod_name: str) -> None:
+        """Delete a run pod by name."""
+        try:
+            self._core.delete_namespaced_pod(
+                name=pod_name,
+                namespace=self._namespace,
+                body=client.V1DeleteOptions(grace_period_seconds=5),
+            )
+        except ApiException as exc:
+            if exc.status != 404:
+                raise
+
+    def list_run_pods(self) -> list[dict]:
+        """List all run pods."""
+        label_selector = "app.kubernetes.io/component=run"
+        pods = self._core.list_namespaced_pod(
+            namespace=self._namespace,
+            label_selector=label_selector,
+        )
+        return [self._pod_to_dict(p) for p in pods.items]

--- a/landing/app/templates/run.html
+++ b/landing/app/templates/run.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ team }}/{{ app_slug }} — SUS</title>
+  <style>
+    :root {
+      --header-height: 48px;
+      --bg: #f5f5f5;
+      --header-bg: #ffffff;
+      --text: #1a1a1a;
+      --muted: #666;
+      --accent: #2563eb;
+      --border: #e0e0e0;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body {
+      height: 100%;
+      overflow: hidden;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
+
+    .header {
+      height: var(--header-height);
+      background: var(--header-bg);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 1rem;
+    }
+
+    .header .app-name {
+      font-size: .95rem;
+      font-weight: 600;
+    }
+
+    .header a {
+      color: var(--accent);
+      text-decoration: none;
+      font-size: .85rem;
+      font-weight: 500;
+    }
+    .header a:hover {
+      text-decoration: underline;
+    }
+
+    .app-frame {
+      width: 100%;
+      height: calc(100% - var(--header-height));
+      border: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <span class="app-name">{{ team }}/{{ app_slug }}</span>
+    <a href="/">Back to catalog</a>
+  </div>
+  <iframe class="app-frame" src="/run/{{ team }}/{{ app_slug }}/proxy/"></iframe>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `landing/app/run_pods.py` — `RunPodManager` for creating/managing run pods:
  - Read-only root filesystem, lighter resource limits (128Mi/256Mi)
  - Label-based pod lookup (`find_run_pod`)
- `landing/app/publisher.py` — `Publisher` class:
  - `publish_app()` — rolling update: deletes existing run pod, creates new one from published image
  - Image naming convention: `localhost:5000/sus-app-{team}-{app_slug}:latest`
- `landing/app/routes/run.py` — Run mode router (`/run` prefix):
  - `GET /run/{team}/{app_slug}` — clean, light-themed page with full-page app iframe
  - `GET /run/{team}/{app_slug}/proxy/{path}` — HTTP proxy to run pod (503 if not found)
- `landing/app/templates/run.html` — End-user-facing run mode template
- Updated `main.py` to include run router
- Updated `git_workflow.py` to optionally trigger publish via the Publisher

## Test plan
- [ ] `RunPodManager.create_run_pod()` creates pods with correct labels and read-only rootfs
- [ ] `find_run_pod()` finds existing run pods by team/app labels
- [ ] `Publisher.publish_app()` does rolling update (delete old, create new)
- [ ] `/run/{team}/{app_slug}` renders the run UI with iframe
- [ ] `/run/{team}/{app_slug}/proxy/` proxies to run pod, returns 503 if no pod
- [ ] Publish flow in git_workflow integrates with publisher

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)