### PR TITLE
Complete session resumption with cleanup loop and sessions API

### DIFF
--- a/landing/app/cleanup.py
+++ b/landing/app/cleanup.py
@@ -1,0 +1,41 @@
+"""Background cleanup task — removes idle build pods and their session records."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from .pods import BuildPodManager
+from .sessions import SessionStore
+
+logger = logging.getLogger(__name__)
+
+
+async def start_cleanup_loop(
+    pod_manager: BuildPodManager,
+    session_store: SessionStore,
+    interval_minutes: int = 5,
+    idle_timeout_minutes: int = 10,
+) -> None:
+    """Run an infinite loop that cleans up idle pods and their sessions.
+
+    This is intended to be launched as an ``asyncio`` background task when the
+    FastAPI application starts up.
+    """
+    while True:
+        try:
+            deleted = pod_manager.cleanup_idle_pods(idle_timeout_minutes)
+            for pod_name in deleted:
+                session = session_store.get_by_pod(pod_name)
+                if session:
+                    session_store.delete(session["user_id"], session["app_slug"])
+                    logger.info(
+                        "Cleaned up idle session for %s/%s (pod %s)",
+                        session["user_id"],
+                        session["app_slug"],
+                        pod_name,
+                    )
+        except Exception:
+            logger.exception("Error during cleanup loop iteration")
+
+        await asyncio.sleep(interval_minutes * 60)

--- a/landing/app/main.py
+++ b/landing/app/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -10,9 +11,13 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 
 from .catalog import scan_apps
+from .cleanup import start_cleanup_loop
 from .identity import IdentityProvider, SingleUserProvider, UserIdentity
+from .pods import BuildPodManager
 from .routes.build import router as build_router
 from .routes.run import router as run_router
+from .routes.sessions import router as sessions_router
+from .sessions import SessionStore
 
 # ---------------------------------------------------------------------------
 # Application & templates
@@ -21,6 +26,17 @@ from .routes.run import router as run_router
 app = FastAPI(title="SUS Landing Page", version="0.1.0")
 app.include_router(build_router)
 app.include_router(run_router)
+app.include_router(sessions_router)
+
+
+@app.on_event("startup")
+async def _start_cleanup_task() -> None:
+    """Launch the background cleanup loop when the app starts."""
+    pod_manager = BuildPodManager()
+    session_store = SessionStore()
+    asyncio.create_task(
+        start_cleanup_loop(pod_manager, session_store),
+    )
 
 _templates_dir = Path(__file__).resolve().parent / "templates"
 templates = Jinja2Templates(directory=str(_templates_dir))

--- a/landing/app/routes/build.py
+++ b/landing/app/routes/build.py
@@ -101,6 +101,7 @@ async def build_heartbeat(
         session = wf._sessions.get(user_id, app_slug)
         if session:
             wf._pods.heartbeat(session["pod_name"])
+            wf._sessions.update_last_seen(session["pod_name"])
     except Exception:
         logger.exception("Heartbeat failed for %s/%s", team, app_slug)
     return JSONResponse({"status": "ok"})

--- a/landing/app/routes/sessions.py
+++ b/landing/app/routes/sessions.py
@@ -1,0 +1,82 @@
+"""Session management routes — list, get, and delete build sessions."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse
+
+from ..pods import BuildPodManager
+from ..sessions import SessionStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/sessions")
+
+# ---------------------------------------------------------------------------
+# Lazy-initialised singletons
+# ---------------------------------------------------------------------------
+
+_session_store: Optional[SessionStore] = None
+_pod_manager: Optional[BuildPodManager] = None
+
+
+def _get_session_store() -> SessionStore:
+    global _session_store  # noqa: PLW0603
+    if _session_store is None:
+        _session_store = SessionStore()
+    return _session_store
+
+
+def _get_pod_manager() -> BuildPodManager:
+    global _pod_manager  # noqa: PLW0603
+    if _pod_manager is None:
+        _pod_manager = BuildPodManager()
+    return _pod_manager
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("")
+async def list_sessions(
+    user_id: str = Query(None, alias="user_id"),
+) -> JSONResponse:
+    """List all sessions, optionally filtered by user_id."""
+    store = _get_session_store()
+    sessions = store.list_sessions(user_id=user_id)
+    return JSONResponse({"sessions": sessions})
+
+
+@router.get("/{user_id}/{app_slug}")
+async def get_session(user_id: str, app_slug: str) -> JSONResponse:
+    """Get a specific session by user_id and app_slug."""
+    store = _get_session_store()
+    session = store.get(user_id, app_slug)
+    if session is None:
+        return JSONResponse({"error": "session not found"}, status_code=404)
+    return JSONResponse({"session": session})
+
+
+@router.delete("/{user_id}/{app_slug}")
+async def delete_session(user_id: str, app_slug: str) -> JSONResponse:
+    """End a session — delete the pod and remove the session record."""
+    store = _get_session_store()
+    pod_mgr = _get_pod_manager()
+
+    session = store.get(user_id, app_slug)
+    if session is None:
+        return JSONResponse({"error": "session not found"}, status_code=404)
+
+    # Delete the pod first, then the session record.
+    try:
+        pod_mgr.delete_build_pod(session["pod_name"])
+    except Exception:
+        logger.exception("Failed to delete pod %s", session["pod_name"])
+
+    store.delete(user_id, app_slug)
+    return JSONResponse({"status": "deleted"})


### PR DESCRIPTION
## Summary
- `landing/app/routes/sessions.py` — Sessions API (`/api/sessions`):
  - List all sessions (optional user_id filter)
  - Get specific session
  - Delete session (cleans up pod + record)
- `landing/app/cleanup.py` — Background cleanup loop:
  - Periodically removes idle pods (default: 10 min timeout)
  - Deletes corresponding session records
- Updated `build.py` heartbeat to also update `last_seen` in session store
- Updated `main.py` to register sessions router and start cleanup loop on startup

## Test plan
- [ ] `GET /api/sessions` returns session list
- [ ] `DELETE /api/sessions/{user}/{app}` cleans up pod and record
- [ ] Heartbeat updates both pod annotation and session `last_seen`
- [ ] Cleanup loop removes idle pods and stale sessions

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)