### PR TITLE
Add domain guidance skills and authoring guide

### DIFF
--- a/build-pod/CLAUDE.md
+++ b/build-pod/CLAUDE.md
@@ -43,6 +43,39 @@ session start.
 - Never write credentials or secrets to files — use environment variables injected at runtime.
 - No access to production environments under any circumstance.
 
+## Discovering and Loading Team-Specific Skills
+
+At the start of every build session, load relevant guidance skills from
+`/repo/claude/skills/`. Skills teach Claude about domain-specific conventions,
+table schemas, KPI formulas, and display patterns.
+
+### Loading rules
+
+1. **Always load the baseline skill**: Read `/repo/claude/skills/example.md`
+   into context at session start. It contains platform-wide conventions that
+   apply to every app.
+
+2. **Match skills to the user's team**: When a user is working on an app in
+   `apps/{team}/`, check if `/repo/claude/skills/{team}.md` exists. If it
+   does, load it. For example:
+   - `apps/finance/budget-tracker/` → load `claude/skills/finance.md`
+   - `apps/marketing/campaign-dashboard/` → load `claude/skills/marketing.md`
+   - `apps/customer-success/health-scores/` → load `claude/skills/customer-success.md`
+
+3. **Load multiple skills when relevant**: If the app spans multiple domains
+   (e.g., a finance app that also uses marketing attribution data), load all
+   applicable skills. Use the app description in `sus.json` and the user's
+   requests to determine relevance.
+
+4. **Skills are read-only context**: Do not modify skill files during a build
+   session. They are reference material, not runtime configuration.
+
+5. **Skill authoring**: If a user wants to create or edit a skill, direct
+   them to follow the guide at `/repo/claude/skills/AUTHORING.md` and submit
+   a PR to `claude/skills/`.
+
+---
+
 ## Working Directory
 
 All work happens under `/repo`. The monorepo is cloned here at session start.

--- a/claude/skills/AUTHORING.md
+++ b/claude/skills/AUTHORING.md
@@ -1,0 +1,190 @@
+# Authoring Guidance Skills
+
+This guide explains how to write a guidance skill for the SUS platform.
+Skills are Markdown files that teach Claude about a specific domain so it
+can build better apps for teams working in that area.
+
+---
+
+## What is a skill?
+
+A skill is a plain Markdown file in `claude/skills/` that Claude loads into
+context when building apps for a particular team or domain. Skills contain
+concrete conventions, formulas, table schemas, and patterns that Claude
+follows when generating code.
+
+Skills are **not** code libraries or configuration files. They are
+instructions written in natural language with embedded examples.
+
+---
+
+## When does Claude use skills?
+
+- When a user starts a build session, Claude checks for skills that match
+  the user's team (e.g., `apps/finance/` maps to `claude/skills/finance.md`).
+- `claude/skills/example.md` is always loaded as baseline context.
+- If multiple skills are relevant, Claude loads all of them.
+- Skills supplement Claude's general knowledge with company-specific
+  conventions.
+
+---
+
+## File format and naming
+
+| Rule | Convention |
+|---|---|
+| Location | `claude/skills/` in the monorepo root |
+| File name | `{domain}.md` — lowercase, hyphens for multi-word names |
+| Format | Markdown with a level-1 heading, blockquote summary, and numbered sections |
+| Encoding | UTF-8, LF line endings |
+
+**File name examples**: `finance.md`, `marketing.md`, `customer-success.md`,
+`data-engineering.md`, `sales-ops.md`.
+
+---
+
+## Anatomy of a skill
+
+Every skill should follow this structure:
+
+```markdown
+# Skill: {Domain Name}
+
+> One-line summary of when to use this skill.
+
+---
+
+## 1. {Core Concepts}
+
+Define the key terms, KPIs, or domain objects. Use tables for structured
+definitions. Include formulas where applicable.
+
+## 2. {Table and Column Conventions}
+
+Provide concrete table schemas with column names, types, and comments.
+This is what Claude will use when generating SQL or building data models.
+
+## 3. {Common Query Patterns}
+
+SQL snippets or join patterns that come up frequently in this domain.
+Use parameterized queries (`:param_name`), not hardcoded values.
+
+## 4. {UI and Display Conventions}
+
+How to format values in HTMX templates — currency, percentages, dates,
+color coding. Include Jinja2 snippets.
+
+## 5. {Common Pitfalls}
+
+Mistakes Claude should avoid. Be specific: "Never use floats for money"
+is useful; "Be careful with data" is not.
+```
+
+The section names and count can vary — the structure above is a guideline,
+not a rigid requirement.
+
+---
+
+## What makes a good skill
+
+A good skill is **specific enough that Claude can follow it mechanically**.
+It answers: "If Claude encounters this situation, what exactly should it do?"
+
+### Good examples
+
+- "Store monetary values as integers in cents (`amount_cents`). Never use
+  floats for money."
+- "NPS = %promoters - %detractors, where promoters score 9-10 and
+  detractors score 0-6."
+- "UTM parameters should be normalized to lowercase on ingest."
+- "The `subscriptions` table has columns: `id`, `customer_id`, `plan_id`,
+  `status`, `mrr_cents`, `started_at`, `canceled_at`."
+
+### Bad examples
+
+- "Make sure the data is accurate." (Too vague — how?)
+- "Follow best practices for financial reporting." (Which practices?)
+- "Be careful with customer data." (Not actionable)
+- "Use good SQL." (Meaningless without specifics)
+
+The test: if you removed the skill, would Claude generate noticeably
+different (worse) code? If not, the skill is not specific enough.
+
+---
+
+## What NOT to put in a skill
+
+| Do not include | Why |
+|---|---|
+| Code implementations (full modules, classes) | Skills are guidance, not libraries. Claude generates the code. |
+| Credentials, API keys, secrets | Secrets are injected as environment variables at runtime. Never write them to files. |
+| Runtime configuration (ports, hostnames, env vars) | These belong in deployment config, not skill files. |
+| Personal opinions or preferences | Skills should reflect team conventions, not individual taste. |
+| Lengthy prose without examples | Claude learns better from concrete patterns than from paragraphs of explanation. |
+| Duplicates of existing skills | Check what already exists in `claude/skills/` before writing a new one. |
+
+---
+
+## Template for a new skill
+
+Copy this skeleton and fill in the sections:
+
+```markdown
+# Skill: {Domain Name}
+
+> Use this skill when building apps for {team/domain} — {brief list of
+> app types this skill covers}.
+
+---
+
+## 1. Key Metrics and Definitions
+
+| Metric | Formula | Display format |
+|---|---|---|
+| **{Metric name}** | `{formula}` | {e.g., percentage, currency, integer} |
+
+## 2. Table and Column Conventions
+
+{Provide CREATE TABLE-style schema blocks with column names, types,
+and inline comments explaining each column.}
+
+## 3. Common Query Patterns
+
+{SQL snippets for the most frequent queries in this domain. Use
+`:param_name` for parameters.}
+
+## 4. Display and Formatting
+
+{Jinja2/HTMX patterns for rendering domain-specific values.}
+
+## 5. Common Pitfalls
+
+- **{Pitfall name}**: {Specific explanation of what to avoid and what
+  to do instead.}
+```
+
+---
+
+## How to submit a skill
+
+1. Create a branch: `git checkout -b skills/{domain-name}`.
+2. Add your file at `claude/skills/{domain-name}.md`.
+3. Follow the conventions in this guide.
+4. Open a PR to `main` targeting the `claude/skills/` directory.
+5. In the PR description, explain what team or use case the skill serves.
+6. A reviewer will check that the skill is specific, actionable, and does
+   not contain any of the "do not include" items listed above.
+
+---
+
+## Reviewing skills
+
+When reviewing a skill PR, check for:
+
+- [ ] File is in `claude/skills/` with a lowercase, hyphenated `.md` name
+- [ ] Has a level-1 heading and blockquote summary
+- [ ] Includes concrete table schemas, formulas, or query patterns
+- [ ] Does not contain credentials, secrets, or runtime config
+- [ ] Does not duplicate an existing skill
+- [ ] Pitfalls section is specific and actionable
+- [ ] Examples use parameterized queries, not hardcoded values

--- a/claude/skills/customer-success.md
+++ b/claude/skills/customer-success.md
@@ -1,0 +1,259 @@
+# Skill: Customer Success
+
+> Use this skill when building apps for customer success teams — health score
+> dashboards, NPS trackers, support ticket analyzers, or renewal forecasting
+> tools.
+
+---
+
+## 1. Satisfaction Score Definitions
+
+### NPS (Net Promoter Score)
+
+Survey question: *"On a scale of 0-10, how likely are you to recommend us?"*
+
+| Group | Score range |
+|---|---|
+| Detractors | 0-6 |
+| Passives | 7-8 |
+| Promoters | 9-10 |
+
+**Formula**: `NPS = %promoters - %detractors`
+
+Result ranges from -100 to +100. Display as a signed integer (`+42`, `-15`).
+
+```sql
+SELECT
+  ROUND(
+    100.0 * COUNT(*) FILTER (WHERE score >= 9) / NULLIF(COUNT(*), 0)
+    - 100.0 * COUNT(*) FILTER (WHERE score <= 6) / NULLIF(COUNT(*), 0),
+    0
+  ) AS nps
+FROM nps_responses
+WHERE submitted_at >= :period_start
+  AND submitted_at < :period_end;
+```
+
+### CSAT (Customer Satisfaction Score)
+
+Survey question: *"How satisfied were you with your experience?"* (1-5 scale)
+
+**Formula**: `CSAT = (responses_of_4_or_5 / total_responses) * 100`
+
+Display as a percentage: `87%`.
+
+```sql
+SELECT
+  ROUND(
+    100.0 * COUNT(*) FILTER (WHERE rating >= 4) / NULLIF(COUNT(*), 0),
+    0
+  ) AS csat_percent
+FROM csat_responses
+WHERE submitted_at >= :period_start
+  AND submitted_at < :period_end;
+```
+
+### CES (Customer Effort Score)
+
+Survey question: *"How easy was it to resolve your issue?"* (1-7 scale)
+
+**Formula**: `CES = average of all responses`
+
+Lower is better (less effort). Display with one decimal: `2.3`.
+
+```sql
+SELECT ROUND(AVG(effort_score)::numeric, 1) AS ces
+FROM ces_responses
+WHERE submitted_at >= :period_start
+  AND submitted_at < :period_end;
+```
+
+---
+
+## 2. Table Schemas
+
+### Survey responses
+
+```
+nps_responses
+  id              BIGINT PRIMARY KEY
+  customer_id     BIGINT REFERENCES customers(id)
+  score           INTEGER       -- 0-10
+  comment         TEXT
+  submitted_at    TIMESTAMPTZ
+
+csat_responses
+  id              BIGINT PRIMARY KEY
+  customer_id     BIGINT REFERENCES customers(id)
+  ticket_id       BIGINT        -- nullable, links to the interaction
+  rating          INTEGER       -- 1-5
+  comment         TEXT
+  submitted_at    TIMESTAMPTZ
+
+ces_responses
+  id              BIGINT PRIMARY KEY
+  customer_id     BIGINT REFERENCES customers(id)
+  ticket_id       BIGINT
+  effort_score    INTEGER       -- 1-7
+  comment         TEXT
+  submitted_at    TIMESTAMPTZ
+```
+
+### Support tickets
+
+```
+support_tickets
+  id              BIGINT PRIMARY KEY
+  customer_id     BIGINT REFERENCES customers(id)
+  assigned_to     BIGINT        -- CSM user ID
+  subject         TEXT
+  category        TEXT          -- see categorization below
+  priority        TEXT          -- 'low', 'medium', 'high', 'urgent'
+  status          TEXT          -- 'open', 'pending', 'resolved', 'closed'
+  channel         TEXT          -- 'email', 'chat', 'phone', 'self_service'
+  first_response_at TIMESTAMPTZ
+  resolved_at     TIMESTAMPTZ
+  created_at      TIMESTAMPTZ
+```
+
+---
+
+## 3. Customer Segmentation
+
+Segment customers using ARR tiers. Use these defaults unless the user
+provides different thresholds.
+
+| Segment | ARR range | Typical characteristics |
+|---|---|---|
+| **Enterprise** | >= $100,000 | Dedicated CSM, custom contracts, quarterly business reviews |
+| **Mid-Market** | $10,000 - $99,999 | Pooled CSM, standard contracts, semi-annual check-ins |
+| **SMB** | < $10,000 | Tech-touch only, self-service, automated outreach |
+
+### Segmentation query
+
+```sql
+SELECT
+  c.id,
+  c.name,
+  SUM(s.mrr_cents) * 12 AS arr_cents,
+  CASE
+    WHEN SUM(s.mrr_cents) * 12 >= 10000000 THEN 'enterprise'   -- $100k+
+    WHEN SUM(s.mrr_cents) * 12 >= 1000000  THEN 'mid_market'   -- $10k+
+    ELSE 'smb'
+  END AS segment
+FROM customers c
+JOIN subscriptions s ON s.customer_id = c.id AND s.status = 'active'
+GROUP BY c.id, c.name;
+```
+
+### Segment-specific defaults
+
+When building CS dashboards, tailor the default view by segment:
+
+- **Enterprise**: Show individual account details, contact history, renewal
+  date, and expansion opportunities.
+- **Mid-Market**: Show account lists sorted by health score with batch
+  action capabilities.
+- **SMB**: Show aggregate metrics — cohort health, churn trends, automated
+  campaign performance.
+
+---
+
+## 4. Health Score
+
+A customer health score predicts churn risk. Use a weighted composite of
+these signals.
+
+| Component | Weight | Calculation | Good | At risk |
+|---|---|---|---|---|
+| **Product usage** | 30% | `active_days_last_30 / 30` | >= 0.6 | < 0.3 |
+| **Support sentiment** | 20% | Average CSAT over last 90 days, normalized 0-1 | >= 0.8 | < 0.5 |
+| **NPS** | 15% | Latest NPS response, normalized 0-1 (`(score) / 10`) | >= 0.8 | < 0.6 |
+| **Contract status** | 15% | 1 if renewal > 90 days out, 0.5 if 30-90 days, 0 if < 30 days | 1.0 | 0 |
+| **Support ticket volume** | 10% | Inverse: `1 - min(open_tickets / 5, 1)` | >= 0.8 | < 0.4 |
+| **Engagement** | 10% | `logins_last_30 / expected_logins` capped at 1.0 | >= 0.7 | < 0.3 |
+
+**Overall score**: Weighted sum, scaled 0-100.
+
+```python
+def health_score(
+    usage_ratio: float,
+    avg_csat: float,       # 0-1 normalized
+    nps_score: int,        # 0-10
+    days_to_renewal: int,
+    open_tickets: int,
+    login_ratio: float,
+) -> int:
+    components = {
+        "product_usage": min(usage_ratio, 1.0) * 30,
+        "support_sentiment": min(avg_csat, 1.0) * 20,
+        "nps": (nps_score / 10) * 15,
+        "contract_status": (
+            15 if days_to_renewal > 90
+            else 7.5 if days_to_renewal > 30
+            else 0
+        ),
+        "ticket_volume": max(1 - open_tickets / 5, 0) * 10,
+        "engagement": min(login_ratio, 1.0) * 10,
+    }
+    return round(sum(components.values()))
+```
+
+### Display conventions
+
+| Score range | Label | Color |
+|---|---|---|
+| 80-100 | Healthy | `text-green-600` / `bg-green-50` |
+| 50-79 | Needs attention | `text-yellow-600` / `bg-yellow-50` |
+| 0-49 | At risk | `text-red-600` / `bg-red-50` |
+
+---
+
+## 5. Support Ticket Categorization
+
+Use these standard categories for classifying support tickets.
+
+| Category | Description | Examples |
+|---|---|---|
+| `bug_report` | Something is broken | "Dashboard won't load", "Export gives wrong numbers" |
+| `feature_request` | Customer wants new functionality | "Can we add a Slack integration?" |
+| `how_to` | Customer needs help using the product | "How do I set up SSO?" |
+| `billing` | Invoice, payment, or plan questions | "Can we switch to annual billing?" |
+| `account_management` | User access, permissions, settings | "Add a new admin user" |
+| `data_issue` | Incorrect, missing, or delayed data | "My report shows zero revenue for March" |
+| `integration` | Third-party connection problems | "Salesforce sync is failing" |
+| `performance` | Slowness or timeout complaints | "Reports take 30 seconds to load" |
+| `security` | Security or compliance concerns | "We need SOC 2 documentation" |
+| `other` | Does not fit the above | Anything else |
+
+### Ticket volume by category query
+
+```sql
+SELECT
+  category,
+  COUNT(*) AS ticket_count,
+  ROUND(AVG(EXTRACT(EPOCH FROM (resolved_at - created_at)) / 3600)::numeric, 1)
+    AS avg_resolution_hours
+FROM support_tickets
+WHERE created_at >= :period_start
+  AND created_at < :period_end
+GROUP BY category
+ORDER BY ticket_count DESC;
+```
+
+---
+
+## 6. Common Pitfalls
+
+- **NPS sample bias**: Low response rates skew NPS. Always display the
+  response count alongside the score so users know if it is meaningful.
+- **Health score stale data**: If a component has no recent data (e.g., no
+  CSAT responses in 90 days), flag it rather than using an old value. Show
+  "No data" instead of a misleading number.
+- **Segment threshold changes**: When a customer's ARR crosses a segment
+  boundary, their CSM assignment and touchpoint cadence should change.
+  Surface these transitions in the UI.
+- **First response time**: Measure from ticket creation to the first
+  **human** response, not automated acknowledgments.
+- **Renewal date accuracy**: Always pull renewal dates from the subscription
+  system, not from manually entered fields that may be stale.

--- a/claude/skills/finance.md
+++ b/claude/skills/finance.md
@@ -1,0 +1,192 @@
+# Skill: Finance
+
+> Use this skill when building apps for finance teams — dashboards, reporting
+> tools, forecasting models, or anything that touches financial data.
+
+---
+
+## 1. Common Financial KPIs
+
+When a user asks for a financial metric, use these definitions unless they
+specify otherwise.
+
+| KPI | Formula | Notes |
+|---|---|---|
+| **Revenue** | Sum of all closed invoices in the period | Always use the invoice `closed_at` date, not `created_at` |
+| **MRR** (Monthly Recurring Revenue) | Sum of active subscriptions' monthly value at period end | Normalize annual plans: `annual_price / 12` |
+| **ARR** (Annual Recurring Revenue) | `MRR * 12` | Snapshot metric — use the last day of the period |
+| **Net New MRR** | `new_mrr + expansion_mrr - contraction_mrr - churned_mrr` | Break this down in the UI so users see the components |
+| **Churn Rate** | `lost_customers_in_period / customers_at_start_of_period` | Express as a percentage. Use customer count, not revenue, unless the user says "revenue churn" |
+| **Revenue Churn** | `lost_mrr_in_period / mrr_at_start_of_period` | Distinct from logo churn — always clarify which one is being used |
+| **CAC** (Customer Acquisition Cost) | `total_sales_and_marketing_spend / new_customers_acquired` | Period must match — same month/quarter for spend and acquisition |
+| **LTV** (Lifetime Value) | `average_revenue_per_account / revenue_churn_rate` | Simple model. For cohort-based LTV, sum revenue per cohort over time |
+| **LTV:CAC Ratio** | `ltv / cac` | Healthy benchmark is 3:1 or higher |
+| **Gross Margin** | `(revenue - cogs) / revenue` | Express as a percentage |
+| **Burn Rate** | `cash_balance_start - cash_balance_end` over the period | Monthly burn is the standard unit |
+| **Runway** | `current_cash_balance / monthly_burn_rate` | Express in months |
+
+---
+
+## 2. Table and Column Naming Conventions
+
+Use these table and column names when generating SQL or building schemas for
+finance apps. This keeps things consistent across the platform.
+
+### Core tables
+
+```
+subscriptions
+  id              BIGINT PRIMARY KEY
+  customer_id     BIGINT REFERENCES customers(id)
+  plan_id         BIGINT REFERENCES plans(id)
+  status          TEXT        -- 'active', 'canceled', 'past_due', 'trialing'
+  mrr_cents       INTEGER     -- monthly value in cents (avoid floats for money)
+  started_at      TIMESTAMPTZ
+  canceled_at     TIMESTAMPTZ
+  current_period_start TIMESTAMPTZ
+  current_period_end   TIMESTAMPTZ
+
+invoices
+  id              BIGINT PRIMARY KEY
+  customer_id     BIGINT REFERENCES customers(id)
+  subscription_id BIGINT REFERENCES subscriptions(id)
+  amount_cents    INTEGER
+  currency        TEXT        -- ISO 4217: 'USD', 'EUR', 'GBP'
+  status          TEXT        -- 'draft', 'open', 'paid', 'void', 'uncollectible'
+  issued_at       TIMESTAMPTZ
+  paid_at         TIMESTAMPTZ
+  closed_at       TIMESTAMPTZ
+
+plans
+  id              BIGINT PRIMARY KEY
+  name            TEXT
+  interval        TEXT        -- 'month', 'year'
+  amount_cents    INTEGER
+  currency        TEXT
+
+expenses
+  id              BIGINT PRIMARY KEY
+  category        TEXT        -- 'payroll', 'marketing', 'infrastructure', 'other'
+  amount_cents    INTEGER
+  currency        TEXT
+  incurred_at     TIMESTAMPTZ
+  department      TEXT
+```
+
+### Naming rules
+
+- Store monetary values as **integers in cents** (`amount_cents`). Never use
+  floats for money.
+- Always include a `currency` column — never assume USD.
+- Timestamps use `TIMESTAMPTZ` and end with `_at`.
+- Status columns use lowercase text enums, not integer codes.
+
+---
+
+## 3. Common Join Patterns
+
+### MRR by month
+
+```sql
+SELECT
+  date_trunc('month', s.current_period_start) AS month,
+  SUM(s.mrr_cents) AS total_mrr_cents
+FROM subscriptions s
+WHERE s.status = 'active'
+GROUP BY 1
+ORDER BY 1;
+```
+
+### Revenue by customer for a period
+
+```sql
+SELECT
+  c.id AS customer_id,
+  c.name,
+  SUM(i.amount_cents) AS revenue_cents
+FROM invoices i
+JOIN customers c ON c.id = i.customer_id
+WHERE i.status = 'paid'
+  AND i.paid_at >= :period_start
+  AND i.paid_at < :period_end
+GROUP BY c.id, c.name
+ORDER BY revenue_cents DESC;
+```
+
+### CAC calculation
+
+```sql
+SELECT
+  date_trunc('month', c.created_at) AS cohort_month,
+  SUM(e.amount_cents) FILTER (WHERE e.category IN ('marketing', 'sales'))
+    AS acquisition_spend_cents,
+  COUNT(DISTINCT c.id) AS new_customers,
+  SUM(e.amount_cents) FILTER (WHERE e.category IN ('marketing', 'sales'))
+    / NULLIF(COUNT(DISTINCT c.id), 0) AS cac_cents
+FROM customers c
+LEFT JOIN expenses e
+  ON date_trunc('month', e.incurred_at) = date_trunc('month', c.created_at)
+WHERE c.created_at >= :period_start
+  AND c.created_at < :period_end
+GROUP BY 1
+ORDER BY 1;
+```
+
+---
+
+## 4. Formatting Currency and Percentages in HTMX Apps
+
+### Currency
+
+In Jinja2 templates, format money like this:
+
+```jinja2
+{# Convert cents to dollars and format with commas #}
+${{ "{:,.2f}".format(amount_cents / 100) }}
+```
+
+For multi-currency support, pass the currency code and use a helper:
+
+```python
+def format_currency(amount_cents: int, currency: str = "USD") -> str:
+    symbols = {"USD": "$", "EUR": "\u20ac", "GBP": "\u00a3"}
+    symbol = symbols.get(currency, currency + " ")
+    return f"{symbol}{amount_cents / 100:,.2f}"
+```
+
+### Percentages
+
+- Churn, margins, and rates: display with one decimal place (`4.2%`).
+- Growth rates: display with one decimal place and a `+`/`-` prefix
+  (`+12.3%`, `-2.1%`).
+
+```jinja2
+{{ "{:+.1f}%".format(growth_rate * 100) }}
+```
+
+### Color conventions
+
+- **Green** for positive changes (revenue up, churn down).
+- **Red** for negative changes (revenue down, churn up).
+- Use Tailwind classes: `text-green-600` / `text-red-600`.
+
+```jinja2
+<span class="{{ 'text-green-600' if delta >= 0 else 'text-red-600' }}">
+  {{ "{:+.1f}%".format(delta * 100) }}
+</span>
+```
+
+---
+
+## 5. Common Pitfalls
+
+- **Float arithmetic on money**: Never do it. Always store and compute in
+  cents, convert to dollars only at display time.
+- **Timezone confusion**: Financial reports must use a consistent timezone.
+  Default to UTC unless the user specifies a reporting timezone.
+- **MRR vs. revenue**: MRR is a snapshot of recurring subscription value.
+  Revenue is what was actually invoiced and paid. Do not mix them.
+- **Churn denominator**: Use the customer count at the **start** of the
+  period, not the end. Using the end count under-reports churn.
+- **Annualizing monthly data**: Only annualize full months. If the current
+  month is partial, exclude it or clearly label it as a projection.

--- a/claude/skills/marketing.md
+++ b/claude/skills/marketing.md
@@ -1,0 +1,230 @@
+# Skill: Marketing
+
+> Use this skill when building apps for marketing teams — campaign trackers,
+> attribution dashboards, funnel analyzers, or any tool that works with
+> marketing data.
+
+---
+
+## 1. Campaign Funnel Stages
+
+Marketing funnels follow these standard stages. Use these names and ordering
+in any funnel visualization or report.
+
+| Stage | Description | Typical events |
+|---|---|---|
+| **Awareness** | User first encounters the brand | `page_view`, `ad_impression`, `social_view` |
+| **Consideration** | User engages with content or product | `content_download`, `video_watch`, `pricing_page_view` |
+| **Conversion** | User takes a desired action | `signup`, `form_submit`, `purchase`, `trial_start` |
+| **Retention** | User returns and continues engaging | `login`, `feature_use`, `subscription_renewal` |
+
+### Funnel query pattern
+
+```sql
+SELECT
+  stage,
+  COUNT(DISTINCT user_id) AS users
+FROM events
+WHERE campaign_id = :campaign_id
+  AND event_time >= :start AND event_time < :end
+GROUP BY stage
+ORDER BY
+  CASE stage
+    WHEN 'awareness' THEN 1
+    WHEN 'consideration' THEN 2
+    WHEN 'conversion' THEN 3
+    WHEN 'retention' THEN 4
+  END;
+```
+
+When building funnel charts, calculate the drop-off rate between each stage:
+
+```python
+def funnel_dropoff(stages: list[dict]) -> list[dict]:
+    """Add conversion_rate and dropoff_rate to each stage."""
+    for i, stage in enumerate(stages):
+        if i == 0:
+            stage["conversion_rate"] = 1.0
+        else:
+            prev = stages[i - 1]["users"]
+            stage["conversion_rate"] = stage["users"] / prev if prev else 0
+        stage["dropoff_rate"] = 1 - stage["conversion_rate"]
+    return stages
+```
+
+---
+
+## 2. UTM Parameter Conventions
+
+When parsing or generating UTM-tagged URLs, follow this standard:
+
+| Parameter | Purpose | Example values |
+|---|---|---|
+| `utm_source` | Where the traffic comes from | `google`, `facebook`, `newsletter`, `partner_blog` |
+| `utm_medium` | Marketing channel type | `cpc`, `email`, `social`, `referral`, `organic` |
+| `utm_campaign` | Specific campaign name | `spring_sale_2026`, `product_launch_q1` |
+| `utm_term` | Paid search keyword | `crm+software`, `project+management` |
+| `utm_content` | Differentiates ad variants | `header_cta`, `sidebar_banner`, `blue_button` |
+
+### Table schema for UTM tracking
+
+```
+page_views
+  id              BIGINT PRIMARY KEY
+  user_id         BIGINT
+  session_id      TEXT
+  url             TEXT
+  utm_source      TEXT
+  utm_medium      TEXT
+  utm_campaign    TEXT
+  utm_term        TEXT
+  utm_content     TEXT
+  referrer        TEXT
+  viewed_at       TIMESTAMPTZ
+```
+
+### Parsing UTMs in Python
+
+```python
+from urllib.parse import urlparse, parse_qs
+
+def extract_utms(url: str) -> dict:
+    params = parse_qs(urlparse(url).query)
+    return {
+        "utm_source": params.get("utm_source", [None])[0],
+        "utm_medium": params.get("utm_medium", [None])[0],
+        "utm_campaign": params.get("utm_campaign", [None])[0],
+        "utm_term": params.get("utm_term", [None])[0],
+        "utm_content": params.get("utm_content", [None])[0],
+    }
+```
+
+### Naming rules
+
+- All lowercase, underscores instead of spaces: `spring_sale_2026`, not
+  `Spring Sale 2026`.
+- No special characters beyond underscores and hyphens.
+- Campaign names should follow the pattern: `{initiative}_{quarter_or_date}`.
+
+---
+
+## 3. Event Taxonomy
+
+Use these event names when building analytics or tracking tools. They follow
+a `noun_verb` pattern in `snake_case`.
+
+### Standard events
+
+| Event name | When it fires | Required properties |
+|---|---|---|
+| `page_view` | User loads a page | `url`, `referrer`, `session_id` |
+| `click` | User clicks a tracked element | `element_id`, `element_text`, `url` |
+| `form_submit` | User submits a form | `form_id`, `form_name`, `fields_count` |
+| `signup` | User creates an account | `method` (`email`, `google`, `sso`) |
+| `login` | User signs in | `method` |
+| `purchase` | User completes a transaction | `amount_cents`, `currency`, `product_id` |
+| `trial_start` | User begins a free trial | `plan_id` |
+| `content_download` | User downloads a resource | `content_id`, `content_type` |
+| `video_watch` | User watches a video | `video_id`, `duration_seconds`, `percent_watched` |
+| `email_open` | Recipient opens an email | `email_campaign_id` |
+| `email_click` | Recipient clicks a link in email | `email_campaign_id`, `link_url` |
+| `ad_impression` | Ad is displayed to a user | `ad_id`, `placement`, `campaign_id` |
+| `ad_click` | User clicks an ad | `ad_id`, `placement`, `campaign_id` |
+
+### Events table schema
+
+```
+events
+  id              BIGINT PRIMARY KEY
+  user_id         BIGINT
+  session_id      TEXT
+  event_name      TEXT          -- one of the standard event names above
+  properties      JSONB         -- event-specific key-value pairs
+  campaign_id     BIGINT        -- nullable, set when attributable to a campaign
+  stage           TEXT          -- funnel stage: awareness, consideration, conversion, retention
+  event_time      TIMESTAMPTZ
+  created_at      TIMESTAMPTZ DEFAULT now()
+```
+
+---
+
+## 4. Common Marketing Metrics
+
+Use these formulas when a user asks for marketing KPIs.
+
+| Metric | Formula | Display format |
+|---|---|---|
+| **CTR** (Click-Through Rate) | `clicks / impressions` | Percentage, 2 decimals: `2.34%` |
+| **Conversion Rate** | `conversions / total_visitors` (or clicks) | Percentage, 2 decimals: `5.12%` |
+| **ROAS** (Return on Ad Spend) | `revenue_from_campaign / ad_spend` | Ratio with 2 decimals: `3.45x` |
+| **CPA** (Cost per Acquisition) | `total_spend / conversions` | Currency: `$42.50` |
+| **CPM** (Cost per Mille) | `(total_spend / impressions) * 1000` | Currency: `$8.20` |
+| **CPC** (Cost per Click) | `total_spend / clicks` | Currency: `$1.15` |
+| **Bounce Rate** | `single_page_sessions / total_sessions` | Percentage, 1 decimal: `45.2%` |
+| **Email Open Rate** | `unique_opens / delivered_emails` | Percentage, 1 decimal: `22.5%` |
+| **Unsubscribe Rate** | `unsubscribes / delivered_emails` | Percentage, 2 decimals: `0.34%` |
+
+### ROAS query example
+
+```sql
+SELECT
+  c.name AS campaign_name,
+  SUM(e.amount_cents) FILTER (WHERE e.category = 'ad_spend') AS spend_cents,
+  SUM(p.amount_cents) AS revenue_cents,
+  ROUND(
+    SUM(p.amount_cents)::numeric
+    / NULLIF(SUM(e.amount_cents) FILTER (WHERE e.category = 'ad_spend'), 0),
+    2
+  ) AS roas
+FROM campaigns c
+LEFT JOIN expenses e ON e.campaign_id = c.id
+LEFT JOIN purchases p ON p.campaign_id = c.id
+WHERE c.started_at >= :start AND c.started_at < :end
+GROUP BY c.id, c.name
+ORDER BY roas DESC;
+```
+
+---
+
+## 5. HTMX Patterns for Marketing Dashboards
+
+### Campaign selector with live-updating metrics
+
+```html
+<select name="campaign_id"
+        hx-get="/api/campaign-metrics"
+        hx-target="#metrics-panel"
+        hx-trigger="change">
+  {% for c in campaigns %}
+  <option value="{{ c.id }}">{{ c.name }}</option>
+  {% endfor %}
+</select>
+
+<div id="metrics-panel">
+  {# Metrics load here via HTMX #}
+</div>
+```
+
+### Date range filter
+
+```html
+<form hx-get="/api/funnel" hx-target="#funnel-chart" hx-trigger="change">
+  <input type="date" name="start" value="{{ default_start }}">
+  <input type="date" name="end" value="{{ default_end }}">
+</form>
+```
+
+---
+
+## 6. Common Pitfalls
+
+- **Attribution double-counting**: A user may interact with multiple campaigns.
+  Use last-touch attribution by default unless the user specifies otherwise.
+- **Impressions vs. reach**: Impressions count every display. Reach counts
+  unique users. Always clarify which one the user wants.
+- **Mixing time windows**: CTR for a day vs. a month can look very different.
+  Always show the time window in the UI.
+- **Zero-division**: Guard against dividing by zero in rate calculations.
+  Use `NULLIF(..., 0)` in SQL and explicit checks in Python.
+- **UTM case sensitivity**: Normalize UTM values to lowercase on ingest.
+  `Google` and `google` should not be treated as separate sources.


### PR DESCRIPTION
## Summary
- `claude/skills/finance.md` — KPIs, table schemas, SQL patterns, currency formatting
- `claude/skills/marketing.md` — Funnel stages, UTM conventions, event taxonomy, metrics
- `claude/skills/customer-success.md` — NPS/CSAT/CES, segmentation, health scores, ticket categories
- `claude/skills/AUTHORING.md` — Guide for writing new skills: format, conventions, template, what to include/avoid
- Updated `build-pod/CLAUDE.md` with team-based skill discovery rules

## Test plan
- [ ] Skills contain concrete, actionable examples (not vague advice)
- [ ] AUTHORING.md includes a copy-paste template skeleton
- [ ] build-pod CLAUDE.md references skill loading by team name
- [ ] All skill files are valid Markdown

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)