### PR TITLE
Add pluggable identity providers and config-driven auth

### DIFF
--- a/landing/app/catalog.py
+++ b/landing/app/catalog.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from typing import Any
 
 
-def scan_apps(root: str | Path | None = None) -> list[dict[str, Any]]:
+def scan_apps(
+    root: str | Path | None = None,
+    user_groups: list[str] | None = None,
+) -> list[dict[str, Any]]:
     """Walk ``apps/{team}/{app-slug}/`` directories and return metadata.
 
     Each directory that contains a ``sus.json`` file is treated as a
@@ -21,6 +24,12 @@ def scan_apps(root: str | Path | None = None) -> list[dict[str, Any]]:
         Filesystem path to the ``apps/`` directory.  Defaults to the
         ``SUS_APPS_ROOT`` environment variable, falling back to
         ``/repo/apps``.
+    user_groups:
+        If provided, only apps whose ``visibility`` list intersects with
+        *user_groups* are returned.  Apps with an empty ``visibility``
+        list or one that contains ``"default"`` are visible to everyone.
+        When *user_groups* is ``None`` all apps are returned (backwards
+        compatible).
     """
 
     if root is None:
@@ -54,6 +63,14 @@ def scan_apps(root: str | Path | None = None) -> list[dict[str, Any]]:
 
             meta["team"] = team
             meta["slug"] = slug
+
+            # Group-based visibility filtering
+            if user_groups is not None:
+                visibility = meta.get("visibility", [])
+                if visibility and "default" not in visibility:
+                    if not set(visibility) & set(user_groups):
+                        continue
+
             apps.append(meta)
 
     return apps

--- a/landing/app/config.py
+++ b/landing/app/config.py
@@ -1,0 +1,56 @@
+"""SUS configuration loader -- reads sus_config.json and builds providers."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from .identity import (
+    IdentityProvider,
+    LocalDatabaseProvider,
+    ProxyHeaderProvider,
+    SingleUserProvider,
+)
+
+_DEFAULT_CONFIG_PATH = "sus_config.json"
+
+_DEFAULT_CONFIG: dict[str, Any] = {
+    "identity_provider": "single-user",
+    "identity_options": {},
+}
+
+
+def load_config() -> dict[str, Any]:
+    """Load and return the SUS configuration dictionary.
+
+    The config file path is determined by the ``SUS_CONFIG_PATH``
+    environment variable, falling back to ``sus_config.json`` in the
+    current working directory.  If the file does not exist, sensible
+    defaults are returned.
+    """
+    path = os.environ.get("SUS_CONFIG_PATH", _DEFAULT_CONFIG_PATH)
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return dict(_DEFAULT_CONFIG)
+
+
+def create_identity_provider(config: dict[str, Any]) -> IdentityProvider:
+    """Instantiate the identity provider described by *config*.
+
+    Raises :class:`ValueError` for unrecognised provider names.
+    """
+    name = config.get("identity_provider", "single-user")
+    options = config.get("identity_options", {})
+
+    if name == "single-user":
+        return SingleUserProvider()
+    if name == "proxy-header":
+        return ProxyHeaderProvider()
+    if name == "local-database":
+        return LocalDatabaseProvider(
+            db_path=options.get("db_path", "users.db")
+        )
+    raise ValueError(f"Unknown identity provider: {name!r}")

--- a/landing/app/identity.py
+++ b/landing/app/identity.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 import abc
+import hashlib
+import json
+import os
+import secrets
+import sqlite3
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Sequence
 
 from starlette.requests import Request
@@ -44,3 +50,182 @@ class SingleUserProvider(IdentityProvider):
             display_name="Local Operator",
             groups=["default"],
         )
+
+
+class ProxyHeaderProvider(IdentityProvider):
+    """Identity provider that trusts reverse-proxy forwarded headers.
+
+    Expects the upstream proxy to set:
+    - ``X-Forwarded-User`` or ``X-Forwarded-Email`` -- user identifier
+    - ``X-Forwarded-Name`` -- display name (falls back to user ID)
+    - ``X-Forwarded-Groups`` -- comma-separated group list
+    """
+
+    async def resolve(self, request: Request) -> UserIdentity:
+        user_id = request.headers.get(
+            "X-Forwarded-User"
+        ) or request.headers.get("X-Forwarded-Email")
+
+        if not user_id:
+            return UserIdentity(
+                id="guest",
+                display_name="Guest",
+                groups=["guest"],
+            )
+
+        display_name = request.headers.get("X-Forwarded-Name") or user_id
+        groups_header = request.headers.get("X-Forwarded-Groups", "default")
+        groups = [g.strip() for g in groups_header.split(",") if g.strip()]
+
+        return UserIdentity(
+            id=user_id,
+            display_name=display_name,
+            groups=groups if groups else ["default"],
+        )
+
+
+class LocalDatabaseProvider(IdentityProvider):
+    """SQLite-backed local user database with session management."""
+
+    _SALT_LENGTH = 16
+    _HASH_ITERATIONS = 260_000
+    _SESSION_TTL_HOURS = 24
+
+    def __init__(self, db_path: str = "users.db") -> None:
+        self.db_path = db_path
+        self._init_db()
+
+    # -- database setup ------------------------------------------------------
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    username TEXT UNIQUE NOT NULL,
+                    password_hash TEXT NOT NULL,
+                    display_name TEXT NOT NULL,
+                    groups TEXT NOT NULL DEFAULT '["default"]',
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    token TEXT PRIMARY KEY,
+                    user_id INTEGER NOT NULL REFERENCES users(id),
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    expires_at TEXT NOT NULL
+                )
+                """
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    # -- password hashing ----------------------------------------------------
+
+    @staticmethod
+    def _hash_password(password: str, salt: bytes | None = None) -> str:
+        if salt is None:
+            salt = os.urandom(LocalDatabaseProvider._SALT_LENGTH)
+        dk = hashlib.pbkdf2_hmac(
+            "sha256",
+            password.encode(),
+            salt,
+            LocalDatabaseProvider._HASH_ITERATIONS,
+        )
+        return f"{salt.hex()}:{dk.hex()}"
+
+    @staticmethod
+    def _verify_password(password: str, stored: str) -> bool:
+        salt_hex, _ = stored.split(":", 1)
+        salt = bytes.fromhex(salt_hex)
+        return LocalDatabaseProvider._hash_password(password, salt) == stored
+
+    # -- public API ----------------------------------------------------------
+
+    async def resolve(self, request: Request) -> UserIdentity:
+        token = request.cookies.get("sus_session")
+        if not token:
+            return UserIdentity(
+                id="guest", display_name="Guest", groups=["guest"]
+            )
+
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT u.id, u.username, u.display_name, u.groups
+                FROM sessions s
+                JOIN users u ON u.id = s.user_id
+                WHERE s.token = ? AND s.expires_at > datetime('now')
+                """,
+                (token,),
+            ).fetchone()
+
+        if row is None:
+            return UserIdentity(
+                id="guest", display_name="Guest", groups=["guest"]
+            )
+
+        return UserIdentity(
+            id=str(row["id"]),
+            display_name=row["display_name"],
+            groups=json.loads(row["groups"]),
+        )
+
+    def create_user(
+        self,
+        username: str,
+        password: str,
+        display_name: str,
+        groups: list[str] | None = None,
+    ) -> UserIdentity:
+        groups = groups or ["default"]
+        password_hash = self._hash_password(password)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "INSERT INTO users (username, password_hash, display_name, groups) "
+                "VALUES (?, ?, ?, ?)",
+                (username, password_hash, display_name, json.dumps(groups)),
+            )
+            user_id = cursor.lastrowid
+        return UserIdentity(
+            id=str(user_id), display_name=display_name, groups=groups
+        )
+
+    def authenticate(self, username: str, password: str) -> str | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT id, password_hash FROM users WHERE username = ?",
+                (username,),
+            ).fetchone()
+
+        if row is None or not self._verify_password(
+            password, row["password_hash"]
+        ):
+            return None
+
+        token = secrets.token_urlsafe(32)
+        expires = datetime.now(timezone.utc) + timedelta(
+            hours=self._SESSION_TTL_HOURS
+        )
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO sessions (token, user_id, expires_at) "
+                "VALUES (?, ?, ?)",
+                (
+                    token,
+                    row["id"],
+                    expires.strftime("%Y-%m-%d %H:%M:%S"),
+                ),
+            )
+        return token
+
+    def delete_session(self, token: str) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM sessions WHERE token = ?", (token,))

--- a/landing/app/main.py
+++ b/landing/app/main.py
@@ -12,8 +12,10 @@ from fastapi.templating import Jinja2Templates
 
 from .catalog import scan_apps
 from .cleanup import start_cleanup_loop
-from .identity import IdentityProvider, SingleUserProvider, UserIdentity
+from .config import create_identity_provider, load_config
+from .identity import IdentityProvider, UserIdentity
 from .pods import BuildPodManager
+from .routes.auth import router as auth_router
 from .routes.build import router as build_router
 from .routes.run import router as run_router
 from .routes.sessions import router as sessions_router
@@ -24,6 +26,7 @@ from .sessions import SessionStore
 # ---------------------------------------------------------------------------
 
 app = FastAPI(title="SUS Landing Page", version="0.1.0")
+app.include_router(auth_router)
 app.include_router(build_router)
 app.include_router(run_router)
 app.include_router(sessions_router)
@@ -45,7 +48,7 @@ templates = Jinja2Templates(directory=str(_templates_dir))
 # Identity dependency
 # ---------------------------------------------------------------------------
 
-_identity_provider: IdentityProvider = SingleUserProvider()
+_identity_provider: IdentityProvider = create_identity_provider(load_config())
 
 
 def get_identity_provider() -> IdentityProvider:
@@ -83,7 +86,7 @@ async def api_catalog(
     identity: UserIdentity = Depends(resolve_identity),
 ) -> list[dict[str, Any]]:
     """Return the discovered app catalog as JSON."""
-    return scan_apps()
+    return scan_apps(user_groups=list(identity.groups) if identity.groups else None)
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -92,7 +95,7 @@ async def index(
     identity: UserIdentity = Depends(resolve_identity),
 ) -> HTMLResponse:
     """Render the landing page with the app catalog."""
-    catalog = scan_apps()
+    catalog = scan_apps(user_groups=list(identity.groups) if identity.groups else None)
     return templates.TemplateResponse(
         request,
         "index.html",

--- a/landing/app/routes/auth.py
+++ b/landing/app/routes/auth.py
@@ -1,0 +1,134 @@
+"""Authentication routes -- active when using the local-database provider."""
+
+from __future__ import annotations
+
+import json as _json
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from ..identity import LocalDatabaseProvider
+
+router = APIRouter(prefix="/auth")
+
+
+def _get_provider(request: Request) -> LocalDatabaseProvider | None:
+    """Return the identity provider only if it is a LocalDatabaseProvider."""
+    from ..main import get_identity_provider
+
+    provider = get_identity_provider()
+    if isinstance(provider, LocalDatabaseProvider):
+        return provider
+    return None
+
+
+@router.post("/login")
+async def login(request: Request) -> JSONResponse:
+    """Authenticate a user and set a session cookie."""
+    provider = _get_provider(request)
+    if provider is None:
+        return JSONResponse(
+            {"error": "Login is only available with the local-database provider"},
+            status_code=400,
+        )
+
+    body = await request.json()
+    username: str = body.get("username", "")
+    password: str = body.get("password", "")
+
+    token = provider.authenticate(username, password)
+    if token is None:
+        return JSONResponse({"error": "Invalid credentials"}, status_code=401)
+
+    with provider._connect() as conn:
+        row = conn.execute(
+            "SELECT u.id, u.display_name, u.groups FROM sessions s "
+            "JOIN users u ON u.id = s.user_id WHERE s.token = ?",
+            (token,),
+        ).fetchone()
+
+    response = JSONResponse(
+        {
+            "id": str(row["id"]),
+            "display_name": row["display_name"],
+            "groups": _json.loads(row["groups"]),
+        }
+    )
+    response.set_cookie(
+        key="sus_session", value=token, httponly=True, samesite="lax"
+    )
+    return response
+
+
+@router.post("/logout")
+async def logout(request: Request) -> JSONResponse:
+    """Clear the session cookie and invalidate the server-side session."""
+    provider = _get_provider(request)
+    token = request.cookies.get("sus_session")
+
+    if provider is not None and token:
+        provider.delete_session(token)
+
+    response = JSONResponse({"status": "ok"})
+    response.delete_cookie(key="sus_session")
+    return response
+
+
+@router.get("/me")
+async def me(request: Request) -> JSONResponse:
+    """Return the current user's identity."""
+    from ..main import get_identity_provider
+
+    provider = get_identity_provider()
+    identity = await provider.resolve(request)
+    return JSONResponse(
+        {
+            "id": identity.id,
+            "display_name": identity.display_name,
+            "groups": list(identity.groups) if identity.groups else [],
+        }
+    )
+
+
+@router.post("/register")
+async def register(request: Request) -> JSONResponse:
+    """Create a new user account (local-database provider only)."""
+    provider = _get_provider(request)
+    if provider is None:
+        return JSONResponse(
+            {
+                "error": (
+                    "Registration is only available with the "
+                    "local-database provider"
+                )
+            },
+            status_code=400,
+        )
+
+    body = await request.json()
+    username: str = body.get("username", "")
+    password: str = body.get("password", "")
+    display_name: str = body.get("display_name", username)
+    groups: list[str] = body.get("groups", ["default"])
+
+    if not username or not password:
+        return JSONResponse(
+            {"error": "Username and password are required"},
+            status_code=400,
+        )
+
+    try:
+        identity = provider.create_user(
+            username, password, display_name, groups
+        )
+    except Exception as exc:
+        return JSONResponse({"error": str(exc)}, status_code=409)
+
+    return JSONResponse(
+        {
+            "id": identity.id,
+            "display_name": identity.display_name,
+            "groups": list(identity.groups) if identity.groups else [],
+        },
+        status_code=201,
+    )

--- a/sus_config.json
+++ b/sus_config.json
@@ -1,0 +1,4 @@
+{
+  "identity_provider": "single-user",
+  "identity_options": {}
+}


### PR DESCRIPTION
## Summary
- Updated `landing/app/identity.py` with two new providers:
  - `ProxyHeaderProvider` — trusts `X-Forwarded-User/Email/Groups/Name` headers
  - `LocalDatabaseProvider` — SQLite-backed user DB with PBKDF2 hashing and session cookies
- `landing/app/config.py` — Config loader with `create_identity_provider()` factory
- `sus_config.json` — Default config (single-user mode)
- `landing/app/routes/auth.py` — Login/logout/register/me endpoints for local-database mode
- Updated `landing/app/catalog.py` — Group-based catalog filtering via `user_groups` param
- Updated `landing/app/main.py` — Config-driven provider, auth router, groups passed to catalog

## Test plan
- [ ] Default config loads SingleUserProvider (backwards compatible)
- [ ] Changing config to `"proxy-header"` reads identity from forwarded headers
- [ ] Changing config to `"local-database"` enables register/login/logout flow
- [ ] Catalog filters apps by user group membership
- [ ] Apps with empty visibility or "default" are visible to all

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)