### PR TITLE
Add catalog search, tagging, and example apps

### DIFF
--- a/apps/example/hello-world/sus.json
+++ b/apps/example/hello-world/sus.json
@@ -5,5 +5,6 @@
   "team": "example",
   "created_at": "2026-03-29",
   "visibility": ["default"],
-  "default_stack": "python+htmx"
+  "default_stack": "python+htmx",
+  "tags": ["demo", "getting-started"]
 }

--- a/apps/finance/budget-dashboard/main.py
+++ b/apps/finance/budget-dashboard/main.py
@@ -1,0 +1,19 @@
+"""Budget Dashboard — finance visualization SUS app."""
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+
+app = FastAPI(title="Budget Dashboard")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    return """<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/>
+<title>Budget Dashboard</title>
+<script src="https://unpkg.com/htmx.org@2.0.4"></script>
+<style>body{font-family:system-ui,sans-serif;max-width:600px;margin:4rem auto;padding:0 1rem}</style>
+</head><body>
+<h1>Budget Dashboard</h1>
+<p>Visualize team budgets and spending trends in real time.</p>
+</body></html>"""

--- a/apps/finance/budget-dashboard/requirements.txt
+++ b/apps/finance/budget-dashboard/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-multipart

--- a/apps/finance/budget-dashboard/sus.json
+++ b/apps/finance/budget-dashboard/sus.json
@@ -1,0 +1,10 @@
+{
+  "name": "Budget Dashboard",
+  "description": "Visualize team budgets and spending trends in real time.",
+  "owner": "finance-team@localhost",
+  "team": "finance",
+  "created_at": "2026-03-29",
+  "visibility": ["default"],
+  "default_stack": "python+htmx",
+  "tags": ["finance", "dashboard"]
+}

--- a/apps/marketing/campaign-tracker/main.py
+++ b/apps/marketing/campaign-tracker/main.py
@@ -1,0 +1,19 @@
+"""Campaign Tracker — marketing analytics SUS app."""
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+
+app = FastAPI(title="Campaign Tracker")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    return """<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/>
+<title>Campaign Tracker</title>
+<script src="https://unpkg.com/htmx.org@2.0.4"></script>
+<style>body{font-family:system-ui,sans-serif;max-width:600px;margin:4rem auto;padding:0 1rem}</style>
+</head><body>
+<h1>Campaign Tracker</h1>
+<p>Track marketing campaign performance across channels.</p>
+</body></html>"""

--- a/apps/marketing/campaign-tracker/requirements.txt
+++ b/apps/marketing/campaign-tracker/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-multipart

--- a/apps/marketing/campaign-tracker/sus.json
+++ b/apps/marketing/campaign-tracker/sus.json
@@ -1,0 +1,10 @@
+{
+  "name": "Campaign Tracker",
+  "description": "Track and measure marketing campaign performance across channels.",
+  "owner": "marketing-team@localhost",
+  "team": "marketing",
+  "created_at": "2026-03-29",
+  "visibility": ["default"],
+  "default_stack": "python+htmx",
+  "tags": ["marketing", "analytics"]
+}

--- a/landing/app/catalog.py
+++ b/landing/app/catalog.py
@@ -11,6 +11,8 @@ from typing import Any
 def scan_apps(
     root: str | Path | None = None,
     user_groups: list[str] | None = None,
+    query: str | None = None,
+    tags: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Walk ``apps/{team}/{app-slug}/`` directories and return metadata.
 
@@ -30,6 +32,12 @@ def scan_apps(
         list or one that contains ``"default"`` are visible to everyone.
         When *user_groups* is ``None`` all apps are returned (backwards
         compatible).
+    query:
+        Case-insensitive substring matched against the app's name,
+        description, and team.  ``None`` means no text filtering.
+    tags:
+        If provided, only apps that have at least one matching tag are
+        returned.  ``None`` means no tag filtering.
     """
 
     if root is None:
@@ -71,6 +79,34 @@ def scan_apps(
                     if not set(visibility) & set(user_groups):
                         continue
 
+            # Text search filtering
+            if query:
+                q = query.lower()
+                haystack = " ".join(
+                    [
+                        meta.get("name", ""),
+                        meta.get("description", ""),
+                        meta.get("team", ""),
+                    ]
+                ).lower()
+                if q not in haystack:
+                    continue
+
+            # Tag filtering
+            if tags:
+                app_tags = set(meta.get("tags", []))
+                if not app_tags & set(tags):
+                    continue
+
             apps.append(meta)
 
     return apps
+
+
+def all_tags(root: str | Path | None = None) -> list[str]:
+    """Return a sorted, deduplicated list of every tag across all apps."""
+    apps = scan_apps(root=root)
+    tag_set: set[str] = set()
+    for app in apps:
+        tag_set.update(app.get("tags", []))
+    return sorted(tag_set)

--- a/landing/app/main.py
+++ b/landing/app/main.py
@@ -6,11 +6,11 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 
-from .catalog import scan_apps
+from .catalog import all_tags, scan_apps
 from .cleanup import start_cleanup_loop
 from .config import create_identity_provider, load_config
 from .identity import IdentityProvider, UserIdentity
@@ -86,23 +86,59 @@ async def readyz() -> dict[str, str]:
 @app.get("/api/catalog")
 async def api_catalog(
     identity: UserIdentity = Depends(resolve_identity),
+    q: str | None = None,
+    tags: list[str] = Query(default=[]),
 ) -> list[dict[str, Any]]:
     """Return the discovered app catalog as JSON."""
-    return scan_apps(user_groups=list(identity.groups) if identity.groups else None)
+    return scan_apps(
+        user_groups=list(identity.groups) if identity.groups else None,
+        query=q or None,
+        tags=tags or None,
+    )
+
+
+@app.get("/api/catalog/html", response_class=HTMLResponse)
+async def api_catalog_html(
+    request: Request,
+    identity: UserIdentity = Depends(resolve_identity),
+    q: str | None = None,
+    tags: list[str] = Query(default=[]),
+) -> HTMLResponse:
+    """Return just the catalog card grid as an HTML fragment for HTMX."""
+    catalog = scan_apps(
+        user_groups=list(identity.groups) if identity.groups else None,
+        query=q or None,
+        tags=tags or None,
+    )
+    return templates.TemplateResponse(
+        request,
+        "catalog_cards.html",
+        context={"catalog": catalog},
+    )
 
 
 @app.get("/", response_class=HTMLResponse)
 async def index(
     request: Request,
     identity: UserIdentity = Depends(resolve_identity),
+    q: str | None = None,
+    tags: list[str] = Query(default=[]),
 ) -> HTMLResponse:
     """Render the landing page with the app catalog."""
-    catalog = scan_apps(user_groups=list(identity.groups) if identity.groups else None)
+    catalog = scan_apps(
+        user_groups=list(identity.groups) if identity.groups else None,
+        query=q or None,
+        tags=tags or None,
+    )
+    available_tags = all_tags()
     return templates.TemplateResponse(
         request,
         "index.html",
         context={
             "identity": identity,
             "catalog": catalog,
+            "available_tags": available_tags,
+            "active_tags": tags or [],
+            "query": q or "",
         },
     )

--- a/landing/app/templates/catalog_cards.html
+++ b/landing/app/templates/catalog_cards.html
@@ -1,0 +1,24 @@
+{% if catalog %}
+{% for app in catalog %}
+<div class="card">
+  <h2>{{ app.name }}</h2>
+  <div class="meta">{{ app.team }} &middot; {{ app.get("owner", "\u2014") }}</div>
+  <div class="description">{{ app.get("description", "") }}</div>
+  {% if app.get("tags") %}
+  <div class="card-tags">
+    {% for tag in app.tags %}
+    <span class="tag-pill tag-pill--card">{{ tag }}</span>
+    {% endfor %}
+  </div>
+  {% endif %}
+  <div class="actions">
+    <a class="btn btn-build" href="/build/{{ app.team }}/{{ app.slug }}">Build</a>
+    <a class="btn btn-run" href="/run/{{ app.team }}/{{ app.slug }}">Run</a>
+  </div>
+</div>
+{% endfor %}
+{% else %}
+<div class="empty" style="grid-column:1/-1">
+  <p>No applications match your search.</p>
+</div>
+{% endif %}

--- a/landing/app/templates/index.html
+++ b/landing/app/templates/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>SUS — Single Use Software</title>
+  <script src="https://unpkg.com/htmx.org@2.0.4"></script>
   <style>
     :root {
       --bg: #f5f5f5;
@@ -34,6 +35,91 @@
     header h1 { font-size: 1.5rem; }
     header p  { color: var(--muted); margin-top: .25rem; }
 
+    /* Search bar */
+    .search-section {
+      max-width: 960px;
+      margin: 0 auto 1rem;
+    }
+
+    .search-input {
+      width: 100%;
+      padding: .6rem 1rem;
+      font-size: 1rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--card-bg);
+      color: var(--text);
+      outline: none;
+      transition: border-color .15s;
+    }
+
+    .search-input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, .12);
+    }
+
+    .search-input::placeholder { color: #aaa; }
+
+    /* Tag filter bar */
+    .tag-bar {
+      max-width: 960px;
+      margin: 0 auto 1.5rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: .4rem;
+    }
+
+    .tag-pill {
+      display: inline-block;
+      padding: .2rem .65rem;
+      font-size: .78rem;
+      font-weight: 500;
+      border-radius: 9999px;
+      cursor: pointer;
+      border: 1px solid var(--border);
+      background: var(--card-bg);
+      color: var(--muted);
+      transition: all .15s;
+      user-select: none;
+    }
+
+    .tag-pill:hover {
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    .tag-pill--active {
+      background: var(--accent);
+      color: #fff;
+      border-color: var(--accent);
+    }
+
+    .tag-pill--active:hover {
+      background: var(--accent-hover);
+      color: #fff;
+    }
+
+    .tag-pill--card {
+      cursor: default;
+      font-size: .72rem;
+      padding: .15rem .5rem;
+      background: #eef2ff;
+      color: var(--accent);
+      border-color: #c7d2fe;
+    }
+
+    .tag-pill--card:hover {
+      color: var(--accent);
+      border-color: #c7d2fe;
+    }
+
+    .card-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: .3rem;
+    }
+
+    /* Catalog grid */
     .catalog {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -52,19 +138,9 @@
       gap: .5rem;
     }
 
-    .card h2 {
-      font-size: 1.1rem;
-    }
-
-    .card .meta {
-      font-size: .85rem;
-      color: var(--muted);
-    }
-
-    .card .description {
-      flex: 1;
-      font-size: .95rem;
-    }
+    .card h2 { font-size: 1.1rem; }
+    .card .meta { font-size: .85rem; color: var(--muted); }
+    .card .description { flex: 1; font-size: .95rem; }
 
     .card .actions {
       display: flex;
@@ -83,16 +159,9 @@
       font-weight: 500;
     }
 
-    .btn-build {
-      background: var(--accent);
-      color: #fff;
-    }
+    .btn-build { background: var(--accent); color: #fff; }
     .btn-build:hover { background: var(--accent-hover); }
-
-    .btn-run {
-      background: var(--border);
-      color: var(--text);
-    }
+    .btn-run { background: var(--border); color: var(--text); }
     .btn-run:hover { background: #d0d0d0; }
 
     .empty {
@@ -110,24 +179,106 @@
     <p>Welcome, {{ identity.display_name }}. Browse, build, or run applications.</p>
   </header>
 
-  {% if catalog %}
-  <section class="catalog">
+  <!-- Search bar -->
+  <div class="search-section">
+    <input
+      class="search-input"
+      type="search"
+      name="q"
+      placeholder="Search apps by name, description, or team..."
+      value="{{ query }}"
+      hx-get="/api/catalog/html"
+      hx-trigger="input changed delay:200ms, search"
+      hx-target="#catalog-grid"
+      hx-include="[name='q'], [name='tags']"
+    />
+  </div>
+
+  <!-- Tag filter pills -->
+  {% if available_tags %}
+  <div class="tag-bar" id="tag-bar">
+    {% for tag in available_tags %}
+    <span
+      class="tag-pill{% if tag in active_tags %} tag-pill--active{% endif %}"
+      data-tag="{{ tag }}"
+      onclick="toggleTag(this)"
+    >{{ tag }}</span>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <!-- Hidden inputs for active tags (used by hx-include) -->
+  <div id="tag-inputs">
+    {% for tag in active_tags %}
+    <input type="hidden" name="tags" value="{{ tag }}" />
+    {% endfor %}
+  </div>
+
+  <!-- Catalog grid -->
+  <section class="catalog" id="catalog-grid">
+    {% if catalog %}
     {% for app in catalog %}
     <div class="card">
       <h2>{{ app.name }}</h2>
-      <div class="meta">{{ app.team }} &middot; {{ app.get("owner", "—") }}</div>
+      <div class="meta">{{ app.team }} &middot; {{ app.get("owner", "\u2014") }}</div>
       <div class="description">{{ app.get("description", "") }}</div>
+      {% if app.get("tags") %}
+      <div class="card-tags">
+        {% for tag in app.tags %}
+        <span class="tag-pill tag-pill--card">{{ tag }}</span>
+        {% endfor %}
+      </div>
+      {% endif %}
       <div class="actions">
         <a class="btn btn-build" href="/build/{{ app.team }}/{{ app.slug }}">Build</a>
         <a class="btn btn-run" href="/run/{{ app.team }}/{{ app.slug }}">Run</a>
       </div>
     </div>
     {% endfor %}
+    {% else %}
+    <div class="empty" style="grid-column:1/-1">
+      <p>No applications found. Start building!</p>
+    </div>
+    {% endif %}
   </section>
-  {% else %}
-  <div class="empty">
-    <p>No applications found. Start building!</p>
-  </div>
-  {% endif %}
+
+  <script>
+    function toggleTag(el) {
+      el.classList.toggle('tag-pill--active');
+      syncTagInputs();
+      triggerSearch();
+    }
+
+    function syncTagInputs() {
+      var container = document.getElementById('tag-inputs');
+      container.innerHTML = '';
+      document.querySelectorAll('.tag-pill--active[data-tag]').forEach(function(pill) {
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'tags';
+        input.value = pill.getAttribute('data-tag');
+        container.appendChild(input);
+      });
+    }
+
+    function triggerSearch() {
+      htmx.ajax('GET', '/api/catalog/html', {
+        target: '#catalog-grid',
+        values: getFilterValues()
+      });
+    }
+
+    function getFilterValues() {
+      var vals = {};
+      var q = document.querySelector('.search-input').value;
+      if (q) vals.q = q;
+      var tags = [];
+      document.querySelectorAll('#tag-inputs input[name="tags"]').forEach(function(el) {
+        tags.push(el.value);
+      });
+      if (tags.length) vals.tags = tags;
+      return vals;
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Live search bar with 200ms debounced HTMX filtering (matches name, description, team)
- Clickable tag pills for filtering; tag pills displayed on each app card
- `sus.json` now supports a `tags` field
- Added 2 example apps (marketing/campaign-tracker, finance/budget-dashboard)
- `GET /api/catalog` accepts `q` and `tags` query params
- `GET /api/catalog/html` returns partial HTML for HTMX swaps

## Test plan
- [ ] Search bar filters apps as you type
- [ ] Clicking a tag filters to apps with that tag
- [ ] Combined search + tag filtering works
- [ ] New example apps appear in the catalog
- [ ] `/api/catalog?q=budget` returns filtered JSON

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)