### PR TITLE
Add usage analytics tracking and dashboard

### DIFF
--- a/landing/app/analytics.py
+++ b/landing/app/analytics.py
@@ -1,0 +1,205 @@
+"""SQLite-backed analytics tracker for usage events and daily stats."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+
+class AnalyticsTracker:
+    """Tracks usage events and computes aggregate statistics."""
+
+    def __init__(self, db_path: str = "analytics.db") -> None:
+        self._db_path = db_path
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS events (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT NOT NULL,
+                user_id    TEXT NOT NULL,
+                team       TEXT NOT NULL DEFAULT '',
+                app_slug   TEXT NOT NULL DEFAULT '',
+                metadata   TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_events_type ON events (event_type);
+            CREATE INDEX IF NOT EXISTS idx_events_user ON events (user_id);
+            CREATE INDEX IF NOT EXISTS idx_events_created ON events (created_at);
+
+            CREATE TABLE IF NOT EXISTS daily_stats (
+                date            TEXT NOT NULL,
+                active_users    INTEGER NOT NULL DEFAULT 0,
+                build_sessions  INTEGER NOT NULL DEFAULT 0,
+                run_sessions    INTEGER NOT NULL DEFAULT 0,
+                apps_published  INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (date)
+            );
+            """
+        )
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Event tracking
+    # ------------------------------------------------------------------
+
+    def track_event(
+        self,
+        event_type: str,
+        user_id: str,
+        team: str = "",
+        app_slug: str = "",
+        metadata: dict | None = None,
+    ) -> None:
+        """Insert an analytics event."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            """
+            INSERT INTO events (event_type, user_id, team, app_slug, metadata, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_type,
+                user_id,
+                team,
+                app_slug,
+                json.dumps(metadata or {}),
+                now,
+            ),
+        )
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def get_events(
+        self,
+        event_type: str | None = None,
+        user_id: str | None = None,
+        since: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        """Query events with optional filters."""
+        clauses: list[str] = []
+        params: list[str | int] = []
+
+        if event_type is not None:
+            clauses.append("event_type = ?")
+            params.append(event_type)
+        if user_id is not None:
+            clauses.append("user_id = ?")
+            params.append(user_id)
+        if since is not None:
+            clauses.append("created_at >= ?")
+            params.append(since)
+
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        query = f"SELECT * FROM events{where} ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+
+        rows = self._conn.execute(query, params).fetchall()
+        results = []
+        for row in rows:
+            d = dict(row)
+            # Parse metadata JSON back to dict
+            try:
+                d["metadata"] = json.loads(d["metadata"])
+            except (json.JSONDecodeError, TypeError):
+                d["metadata"] = {}
+            results.append(d)
+        return results
+
+    def get_daily_stats(self, days: int = 30) -> list[dict]:
+        """Return daily stats for the last N days."""
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+        rows = self._conn.execute(
+            "SELECT * FROM daily_stats WHERE date >= ? ORDER BY date DESC",
+            (cutoff,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def compute_daily_stats(self, date: str) -> dict:
+        """Aggregate events for a given date into the daily_stats table.
+
+        *date* should be in YYYY-MM-DD format.
+        """
+        day_start = f"{date}T00:00:00"
+        day_end = f"{date}T23:59:59"
+
+        active_users = self._conn.execute(
+            "SELECT COUNT(DISTINCT user_id) FROM events WHERE created_at >= ? AND created_at <= ?",
+            (day_start, day_end),
+        ).fetchone()[0]
+
+        build_sessions = self._conn.execute(
+            "SELECT COUNT(*) FROM events WHERE event_type = 'build_view' AND created_at >= ? AND created_at <= ?",
+            (day_start, day_end),
+        ).fetchone()[0]
+
+        run_sessions = self._conn.execute(
+            "SELECT COUNT(*) FROM events WHERE event_type = 'run_view' AND created_at >= ? AND created_at <= ?",
+            (day_start, day_end),
+        ).fetchone()[0]
+
+        apps_published = self._conn.execute(
+            "SELECT COUNT(*) FROM events WHERE event_type = 'app_published' AND created_at >= ? AND created_at <= ?",
+            (day_start, day_end),
+        ).fetchone()[0]
+
+        stats = {
+            "date": date,
+            "active_users": active_users,
+            "build_sessions": build_sessions,
+            "run_sessions": run_sessions,
+            "apps_published": apps_published,
+        }
+
+        self._conn.execute(
+            """
+            INSERT INTO daily_stats (date, active_users, build_sessions, run_sessions, apps_published)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT (date) DO UPDATE SET
+                active_users   = excluded.active_users,
+                build_sessions = excluded.build_sessions,
+                run_sessions   = excluded.run_sessions,
+                apps_published = excluded.apps_published
+            """,
+            (date, active_users, build_sessions, run_sessions, apps_published),
+        )
+        self._conn.commit()
+        return stats
+
+    def get_summary(self) -> dict:
+        """Return high-level summary statistics."""
+        total_users = self._conn.execute(
+            "SELECT COUNT(DISTINCT user_id) FROM events"
+        ).fetchone()[0]
+
+        total_builds = self._conn.execute(
+            "SELECT COUNT(*) FROM events WHERE event_type = 'build_view'"
+        ).fetchone()[0]
+
+        total_runs = self._conn.execute(
+            "SELECT COUNT(*) FROM events WHERE event_type = 'run_view'"
+        ).fetchone()[0]
+
+        week_ago = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+        weekly_active = self._conn.execute(
+            "SELECT COUNT(DISTINCT user_id) FROM events WHERE created_at >= ?",
+            (week_ago,),
+        ).fetchone()[0]
+
+        return {
+            "total_users": total_users,
+            "total_builds": total_builds,
+            "total_runs": total_runs,
+            "weekly_active_users": weekly_active,
+        }

--- a/landing/app/main.py
+++ b/landing/app/main.py
@@ -6,15 +6,18 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 
-from .catalog import scan_apps
+from .catalog import all_tags, scan_apps
 from .cleanup import start_cleanup_loop
 from .config import create_identity_provider, load_config
 from .identity import IdentityProvider, UserIdentity
 from .pods import BuildPodManager
+from .analytics import AnalyticsTracker
+from .middleware import AnalyticsMiddleware
+from .routes.analytics import router as analytics_router
 from .routes.auth import router as auth_router
 from .routes.build import router as build_router
 from .routes.mcp import router as mcp_router
@@ -27,11 +30,16 @@ from .sessions import SessionStore
 # ---------------------------------------------------------------------------
 
 app = FastAPI(title="SUS Landing Page", version="0.1.0")
+app.include_router(analytics_router)
 app.include_router(auth_router)
 app.include_router(build_router)
 app.include_router(mcp_router)
 app.include_router(run_router)
 app.include_router(sessions_router)
+
+# Analytics middleware — tracks page views automatically.
+_analytics_tracker = AnalyticsTracker()
+app.add_middleware(AnalyticsMiddleware, tracker=_analytics_tracker)
 
 
 @app.on_event("startup")
@@ -86,23 +94,59 @@ async def readyz() -> dict[str, str]:
 @app.get("/api/catalog")
 async def api_catalog(
     identity: UserIdentity = Depends(resolve_identity),
+    q: str | None = None,
+    tags: list[str] = Query(default=[]),
 ) -> list[dict[str, Any]]:
     """Return the discovered app catalog as JSON."""
-    return scan_apps(user_groups=list(identity.groups) if identity.groups else None)
+    return scan_apps(
+        user_groups=list(identity.groups) if identity.groups else None,
+        query=q or None,
+        tags=tags or None,
+    )
+
+
+@app.get("/api/catalog/html", response_class=HTMLResponse)
+async def api_catalog_html(
+    request: Request,
+    identity: UserIdentity = Depends(resolve_identity),
+    q: str | None = None,
+    tags: list[str] = Query(default=[]),
+) -> HTMLResponse:
+    """Return just the catalog card grid as an HTML fragment for HTMX."""
+    catalog = scan_apps(
+        user_groups=list(identity.groups) if identity.groups else None,
+        query=q or None,
+        tags=tags or None,
+    )
+    return templates.TemplateResponse(
+        request,
+        "catalog_cards.html",
+        context={"catalog": catalog},
+    )
 
 
 @app.get("/", response_class=HTMLResponse)
 async def index(
     request: Request,
     identity: UserIdentity = Depends(resolve_identity),
+    q: str | None = None,
+    tags: list[str] = Query(default=[]),
 ) -> HTMLResponse:
     """Render the landing page with the app catalog."""
-    catalog = scan_apps(user_groups=list(identity.groups) if identity.groups else None)
+    catalog = scan_apps(
+        user_groups=list(identity.groups) if identity.groups else None,
+        query=q or None,
+        tags=tags or None,
+    )
+    available_tags = all_tags()
     return templates.TemplateResponse(
         request,
         "index.html",
         context={
             "identity": identity,
             "catalog": catalog,
+            "available_tags": available_tags,
+            "active_tags": tags or [],
+            "query": q or "",
         },
     )

--- a/landing/app/middleware.py
+++ b/landing/app/middleware.py
@@ -1,0 +1,90 @@
+"""Analytics middleware — tracks page views and API calls."""
+
+from __future__ import annotations
+
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from .analytics import AnalyticsTracker
+
+logger = logging.getLogger(__name__)
+
+# Paths that should not be tracked.
+_SKIP_PREFIXES = (
+    "/healthz",
+    "/readyz",
+    "/static",
+    "/analytics",
+    "/favicon",
+)
+
+# Map URL path prefixes to event types.
+_EVENT_MAP: list[tuple[str, str]] = [
+    ("/build/", "build_view"),
+    ("/run/", "run_view"),
+    ("/api/catalog", "catalog_view"),
+]
+
+
+class AnalyticsMiddleware(BaseHTTPMiddleware):
+    """FastAPI middleware that records page-view analytics events."""
+
+    def __init__(self, app, tracker: AnalyticsTracker | None = None) -> None:  # noqa: ANN001
+        super().__init__(app)
+        self.tracker = tracker or AnalyticsTracker()
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        path = request.url.path
+
+        # Skip paths we don't want to track.
+        if any(path.startswith(p) for p in _SKIP_PREFIXES):
+            return await call_next(request)
+
+        # Only track GET requests (page views).
+        if request.method == "GET":
+            event_type: str | None = None
+            for prefix, etype in _EVENT_MAP:
+                if path.startswith(prefix):
+                    event_type = etype
+                    break
+
+            # Track the landing/catalog page itself.
+            if path == "/" or path == "":
+                event_type = "catalog_view"
+
+            if event_type is not None:
+                # Extract user identity — best-effort.
+                user_id = "anonymous"
+                try:
+                    # Try reading from request state set by identity middleware.
+                    identity = getattr(request.state, "identity", None)
+                    if identity is not None:
+                        user_id = getattr(identity, "user_id", "anonymous") or "anonymous"
+                except Exception:
+                    pass
+
+                # Extract team/app_slug from path segments if applicable.
+                team = ""
+                app_slug = ""
+                parts = [p for p in path.strip("/").split("/") if p]
+                if len(parts) >= 3 and parts[0] in ("build", "run"):
+                    team = parts[1]
+                    app_slug = parts[2]
+
+                try:
+                    self.tracker.track_event(
+                        event_type=event_type,
+                        user_id=user_id,
+                        team=team,
+                        app_slug=app_slug,
+                        metadata={"path": path, "method": request.method},
+                    )
+                except Exception:
+                    logger.exception("Failed to track analytics event")
+
+        return await call_next(request)

--- a/landing/app/routes/analytics.py
+++ b/landing/app/routes/analytics.py
@@ -1,0 +1,87 @@
+"""Analytics API and dashboard routes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
+
+from ..analytics import AnalyticsTracker
+
+router = APIRouter(prefix="/analytics")
+
+_templates_dir = Path(__file__).resolve().parent.parent / "templates"
+_templates = Jinja2Templates(directory=str(_templates_dir))
+
+# Shared tracker instance (same DB as middleware).
+_tracker: AnalyticsTracker | None = None
+
+
+def _get_tracker() -> AnalyticsTracker:
+    global _tracker  # noqa: PLW0603
+    if _tracker is None:
+        _tracker = AnalyticsTracker()
+    return _tracker
+
+
+# ---------------------------------------------------------------------------
+# HTML dashboard
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_class=HTMLResponse)
+async def analytics_dashboard(request: Request) -> HTMLResponse:
+    """Render the analytics dashboard page."""
+    tracker = _get_tracker()
+    summary = tracker.get_summary()
+    events = tracker.get_events(limit=20)
+    return _templates.TemplateResponse(
+        request,
+        "analytics.html",
+        context={
+            "summary": summary,
+            "events": events,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON API
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/summary")
+async def api_summary() -> JSONResponse:
+    """Return a JSON summary of analytics data."""
+    tracker = _get_tracker()
+    return JSONResponse(tracker.get_summary())
+
+
+@router.get("/api/events")
+async def api_events(
+    event_type: str | None = Query(None),
+    user_id: str | None = Query(None),
+    since: str | None = Query(None),
+    limit: int = Query(100, ge=1, le=1000),
+) -> JSONResponse:
+    """Return a JSON list of analytics events."""
+    tracker = _get_tracker()
+    events = tracker.get_events(
+        event_type=event_type,
+        user_id=user_id,
+        since=since,
+        limit=limit,
+    )
+    return JSONResponse(events)
+
+
+@router.get("/api/daily")
+async def api_daily(
+    days: int = Query(30, ge=1, le=365),
+) -> JSONResponse:
+    """Return JSON daily stats for the last N days."""
+    tracker = _get_tracker()
+    stats = tracker.get_daily_stats(days=days)
+    return JSONResponse(stats)

--- a/landing/app/templates/analytics.html
+++ b/landing/app/templates/analytics.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="refresh" content="30" />
+  <title>SUS — Usage Analytics</title>
+  <style>
+    :root {
+      --bg: #f5f5f5;
+      --card-bg: #ffffff;
+      --text: #1a1a1a;
+      --muted: #666;
+      --accent: #2563eb;
+      --accent-hover: #1d4ed8;
+      --border: #e0e0e0;
+      --radius: 8px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+      padding: 2rem;
+    }
+
+    header {
+      max-width: 960px;
+      margin: 0 auto 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+
+    header h1 { font-size: 1.5rem; }
+
+    header a {
+      color: var(--accent);
+      text-decoration: none;
+      font-size: .9rem;
+    }
+    header a:hover { text-decoration: underline; }
+
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1.25rem;
+      max-width: 960px;
+      margin: 0 auto 2rem;
+    }
+
+    .stat-card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.25rem;
+      text-align: center;
+    }
+
+    .stat-card .value {
+      font-size: 2rem;
+      font-weight: 700;
+      color: var(--accent);
+    }
+
+    .stat-card .label {
+      font-size: .85rem;
+      color: var(--muted);
+      margin-top: .25rem;
+    }
+
+    .section {
+      max-width: 960px;
+      margin: 0 auto 2rem;
+    }
+
+    .section h2 {
+      font-size: 1.15rem;
+      margin-bottom: .75rem;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+
+    th, td {
+      padding: .6rem .85rem;
+      text-align: left;
+      border-bottom: 1px solid var(--border);
+      font-size: .9rem;
+    }
+
+    th {
+      background: var(--bg);
+      font-weight: 600;
+      color: var(--muted);
+      font-size: .8rem;
+      text-transform: uppercase;
+      letter-spacing: .03em;
+    }
+
+    tr:last-child td { border-bottom: none; }
+
+    .empty-row td {
+      text-align: center;
+      color: var(--muted);
+      padding: 2rem;
+    }
+
+    .refresh-note {
+      max-width: 960px;
+      margin: 0 auto;
+      text-align: center;
+      font-size: .8rem;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Usage Analytics</h1>
+    <a href="/">&larr; Back to catalog</a>
+  </header>
+
+  <section class="summary">
+    <div class="stat-card">
+      <div class="value">{{ summary.total_users }}</div>
+      <div class="label">Total Users</div>
+    </div>
+    <div class="stat-card">
+      <div class="value">{{ summary.total_builds }}</div>
+      <div class="label">Total Builds</div>
+    </div>
+    <div class="stat-card">
+      <div class="value">{{ summary.total_runs }}</div>
+      <div class="label">Total Runs</div>
+    </div>
+    <div class="stat-card">
+      <div class="value">{{ summary.weekly_active_users }}</div>
+      <div class="label">Weekly Active Users</div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>Recent Activity</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>Event</th>
+          <th>User</th>
+          <th>Team</th>
+          <th>App</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% if events %}
+          {% for event in events %}
+          <tr>
+            <td>{{ event.created_at[:19] }}</td>
+            <td>{{ event.event_type }}</td>
+            <td>{{ event.user_id }}</td>
+            <td>{{ event.team or "—" }}</td>
+            <td>{{ event.app_slug or "—" }}</td>
+          </tr>
+          {% endfor %}
+        {% else %}
+        <tr class="empty-row">
+          <td colspan="5">No events recorded yet.</td>
+        </tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </section>
+
+  <p class="refresh-note">Auto-refreshes every 30 seconds.</p>
+</body>
+</html>

--- a/landing/app/templates/index.html
+++ b/landing/app/templates/index.html
@@ -107,7 +107,7 @@
 <body>
   <header>
     <h1>SUS — Single Use Software</h1>
-    <p>Welcome, {{ identity.display_name }}. Browse, build, or run applications.</p>
+    <p>Welcome, {{ identity.display_name }}. Browse, build, or run applications. <a href="/analytics" style="color: var(--accent); text-decoration: none; font-size: .85rem; margin-left: .5rem;">Analytics</a></p>
   </header>
 
   {% if catalog %}


### PR DESCRIPTION
## Summary
- `landing/app/analytics.py` — SQLite-backed event tracking and stats aggregation
- `landing/app/middleware.py` — Auto-tracks build_view, run_view, catalog_view events
- `landing/app/routes/analytics.py` — Dashboard and JSON API endpoints
- `landing/app/templates/analytics.html` — Dashboard with summary cards and recent activity table (30s auto-refresh)
- Analytics link added to landing page header

## Test plan
- [ ] Visiting pages generates events in the analytics DB
- [ ] `GET /analytics` renders the dashboard
- [ ] `GET /analytics/api/summary` returns stats JSON
- [ ] `GET /analytics/api/events` returns event list
- [ ] Health checks and analytics endpoints are not tracked

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)