### PR TITLE
Add self-service skill authorship UI

### DIFF
--- a/landing/app/main.py
+++ b/landing/app/main.py
@@ -23,6 +23,7 @@ from .routes.build import router as build_router
 from .routes.mcp import router as mcp_router
 from .routes.run import router as run_router
 from .routes.sessions import router as sessions_router
+from .routes.skills import router as skills_router
 from .sessions import SessionStore
 
 # ---------------------------------------------------------------------------
@@ -36,6 +37,7 @@ app.include_router(build_router)
 app.include_router(mcp_router)
 app.include_router(run_router)
 app.include_router(sessions_router)
+app.include_router(skills_router)
 
 # Analytics middleware — tracks page views automatically.
 _analytics_tracker = AnalyticsTracker()

--- a/landing/app/routes/skills.py
+++ b/landing/app/routes/skills.py
@@ -1,0 +1,193 @@
+"""Skills authoring routes — list, create, edit, delete guidance skills."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import markdown
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from ..skills import SkillsManager
+
+router = APIRouter(prefix="/skills")
+
+_templates_dir = Path(__file__).resolve().parent.parent / "templates"
+_templates = Jinja2Templates(directory=str(_templates_dir))
+
+# Skills live in the repo root under claude/skills/.
+_skills_dir = Path(__file__).resolve().parent.parent.parent.parent / "claude" / "skills"
+_manager = SkillsManager(str(_skills_dir))
+
+
+# ---------------------------------------------------------------------------
+# HTML pages
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_class=HTMLResponse)
+async def skills_list(request: Request) -> HTMLResponse:
+    """Render the skills list page."""
+    skills = _manager.list_skills()
+    return _templates.TemplateResponse(
+        request,
+        "skills_list.html",
+        context={"skills": skills},
+    )
+
+
+@router.get("/new", response_class=HTMLResponse)
+async def skills_new(request: Request) -> HTMLResponse:
+    """Render the create-new-skill form."""
+    return _templates.TemplateResponse(
+        request,
+        "skill_editor.html",
+        context={"mode": "create", "skill": None, "errors": []},
+    )
+
+
+@router.get("/guide", response_class=HTMLResponse)
+async def skills_guide(request: Request) -> HTMLResponse:
+    """Render the AUTHORING.md guide as HTML."""
+    skill = _manager.get_skill("AUTHORING")
+    body_html = ""
+    if skill:
+        body_html = markdown.markdown(
+            skill["content"],
+            extensions=["tables", "fenced_code"],
+        )
+    return _templates.TemplateResponse(
+        request,
+        "skill_view.html",
+        context={
+            "skill_name": "AUTHORING",
+            "content_html": body_html,
+            "is_guide": True,
+        },
+    )
+
+
+@router.get("/{name}", response_class=HTMLResponse)
+async def skills_view(request: Request, name: str) -> HTMLResponse:
+    """Render a single skill as HTML."""
+    skill = _manager.get_skill(name)
+    if skill is None:
+        return HTMLResponse(status_code=404, content="Skill not found")
+    body_html = markdown.markdown(
+        skill["content"],
+        extensions=["tables", "fenced_code"],
+    )
+    return _templates.TemplateResponse(
+        request,
+        "skill_view.html",
+        context={
+            "skill_name": name,
+            "content_html": body_html,
+            "is_guide": False,
+        },
+    )
+
+
+@router.get("/{name}/edit", response_class=HTMLResponse)
+async def skills_edit(request: Request, name: str) -> HTMLResponse:
+    """Render the edit form for an existing skill."""
+    skill = _manager.get_skill(name)
+    if skill is None:
+        return HTMLResponse(status_code=404, content="Skill not found")
+    return _templates.TemplateResponse(
+        request,
+        "skill_editor.html",
+        context={"mode": "edit", "skill": skill, "errors": []},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mutations
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_class=HTMLResponse)
+async def skills_create(
+    request: Request,
+    name: str = Form(...),
+    content: str = Form(...),
+) -> HTMLResponse | RedirectResponse:
+    """Create a new skill from form submission."""
+    # Normalise name.
+    clean_name = name.strip().lower().replace(" ", "-")
+    if not clean_name.endswith(".md"):
+        clean_name = f"{clean_name}.md"
+
+    validation = _manager.validate_skill(content)
+    if not validation["valid"]:
+        return _templates.TemplateResponse(
+            request,
+            "skill_editor.html",
+            context={
+                "mode": "create",
+                "skill": {"name": clean_name.removesuffix(".md"), "content": content},
+                "errors": validation["errors"],
+            },
+        )
+
+    _manager.save_skill(clean_name, content)
+    return RedirectResponse(
+        url=f"/skills/{clean_name.removesuffix('.md')}",
+        status_code=303,
+    )
+
+
+@router.post("/{name}/update", response_class=HTMLResponse)
+async def skills_update(
+    request: Request,
+    name: str,
+    content: str = Form(...),
+) -> HTMLResponse | RedirectResponse:
+    """Update an existing skill (POST override for HTML forms)."""
+    validation = _manager.validate_skill(content)
+    if not validation["valid"]:
+        return _templates.TemplateResponse(
+            request,
+            "skill_editor.html",
+            context={
+                "mode": "edit",
+                "skill": {"name": name, "content": content},
+                "errors": validation["errors"],
+            },
+        )
+
+    _manager.save_skill(f"{name}.md", content)
+    return RedirectResponse(url=f"/skills/{name}", status_code=303)
+
+
+@router.put("/{name}")
+async def skills_put(request: Request, name: str) -> RedirectResponse:
+    """Update a skill via PUT (JSON or form)."""
+    form = await request.form()
+    content = str(form.get("content", ""))
+
+    validation = _manager.validate_skill(content)
+    if not validation["valid"]:
+        return HTMLResponse(status_code=400, content=str(validation["errors"]))
+
+    _manager.save_skill(f"{name}.md", content)
+    return RedirectResponse(url=f"/skills/{name}", status_code=303)
+
+
+@router.delete("/{name}")
+async def skills_delete(name: str) -> RedirectResponse | HTMLResponse:
+    """Delete a skill."""
+    deleted = _manager.delete_skill(name)
+    if not deleted:
+        return HTMLResponse(status_code=400, content="Cannot delete this skill.")
+    return RedirectResponse(url="/skills", status_code=303)
+
+
+@router.post("/{name}/delete")
+async def skills_delete_via_post(name: str) -> RedirectResponse | HTMLResponse:
+    """Delete a skill via POST (for HTML form compatibility)."""
+    deleted = _manager.delete_skill(name)
+    if not deleted:
+        return HTMLResponse(status_code=400, content="Cannot delete this skill.")
+    return RedirectResponse(url="/skills", status_code=303)

--- a/landing/app/skills.py
+++ b/landing/app/skills.py
@@ -1,0 +1,108 @@
+"""Skills manager for reading, writing, and validating guidance skill files."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+class SkillsManager:
+    """Manage guidance skill Markdown files in a directory."""
+
+    def __init__(self, skills_dir: str) -> None:
+        self.skills_dir = Path(skills_dir)
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def list_skills(self) -> list[dict]:
+        """List all skill files with name, description, and path."""
+        skills: list[dict] = []
+        if not self.skills_dir.is_dir():
+            return skills
+
+        for path in sorted(self.skills_dir.glob("*.md")):
+            name = path.stem
+            description = ""
+            try:
+                text = path.read_text(encoding="utf-8")
+                # Description is the first non-empty line after the title line.
+                lines = text.splitlines()
+                past_title = False
+                for line in lines:
+                    stripped = line.strip()
+                    if not past_title:
+                        if stripped.startswith("# "):
+                            past_title = True
+                        continue
+                    if stripped and not stripped.startswith("---"):
+                        # Strip leading blockquote marker if present.
+                        description = stripped.lstrip("> ").rstrip()
+                        break
+            except OSError:
+                pass
+
+            skills.append({
+                "name": name,
+                "description": description,
+                "path": str(path),
+            })
+        return skills
+
+    def get_skill(self, name: str) -> dict | None:
+        """Read a single skill file. Returns name, content, path or None."""
+        path = self.skills_dir / f"{name}.md"
+        if not path.is_file():
+            return None
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        return {
+            "name": name,
+            "content": content,
+            "path": str(path),
+        }
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    def save_skill(self, name: str, content: str) -> None:
+        """Write or overwrite a skill file. *name* must end in .md."""
+        if not name.endswith(".md"):
+            name = f"{name}.md"
+        path = self.skills_dir / name
+        self.skills_dir.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def delete_skill(self, name: str) -> bool:
+        """Delete a skill file. Returns False if file missing or protected."""
+        if name.upper() == "AUTHORING":
+            return False
+        path = self.skills_dir / f"{name}.md"
+        if not path.is_file():
+            return False
+        path.unlink()
+        return True
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate_skill(self, content: str) -> dict:
+        """Basic validation of skill Markdown content."""
+        errors: list[str] = []
+
+        if not content or not content.strip():
+            errors.append("Skill content must not be empty.")
+            return {"valid": False, "errors": errors}
+
+        if not re.search(r"^#\s+\S", content, re.MULTILINE):
+            errors.append("Skill must contain a level-1 heading (# Title).")
+
+        if errors:
+            return {"valid": False, "errors": errors}
+        return {"valid": True}

--- a/landing/app/templates/index.html
+++ b/landing/app/templates/index.html
@@ -176,7 +176,7 @@
 <body>
   <header>
     <h1>SUS — Single Use Software</h1>
-    <p>Welcome, {{ identity.display_name }}. Browse, build, or run applications. <a href="/analytics" style="color: var(--accent); text-decoration: none; font-size: .85rem; margin-left: .5rem;">Analytics</a></p>
+    <p>Welcome, {{ identity.display_name }}. Browse, build, or run applications. <a href="/skills" style="color: var(--accent); text-decoration: none; font-size: .85rem; margin-left: .5rem;">Skills</a> <a href="/analytics" style="color: var(--accent); text-decoration: none; font-size: .85rem; margin-left: .5rem;">Analytics</a></p>
   </header>
 
   <!-- Search bar -->

--- a/landing/app/templates/skill_editor.html
+++ b/landing/app/templates/skill_editor.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% if mode == 'create' %}New Skill{% else %}Edit {{ skill.name }}{% endif %} — SUS</title>
+  <style>
+    :root {
+      --bg: #f5f5f5;
+      --card-bg: #ffffff;
+      --text: #1a1a1a;
+      --muted: #666;
+      --accent: #2563eb;
+      --accent-hover: #1d4ed8;
+      --border: #e0e0e0;
+      --radius: 8px;
+      --danger: #dc2626;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+      padding: 2rem;
+    }
+
+    .container {
+      max-width: 760px;
+      margin: 0 auto;
+    }
+
+    h1 { font-size: 1.5rem; margin-bottom: 1.5rem; }
+
+    .errors {
+      background: #fef2f2;
+      border: 1px solid var(--danger);
+      border-radius: var(--radius);
+      padding: .75rem 1rem;
+      margin-bottom: 1rem;
+      color: var(--danger);
+      font-size: .9rem;
+    }
+
+    .errors ul { margin-left: 1.25rem; }
+
+    label {
+      display: block;
+      font-weight: 600;
+      margin-bottom: .35rem;
+      font-size: .9rem;
+    }
+
+    input[type="text"], textarea {
+      width: 100%;
+      padding: .55rem .75rem;
+      font-size: .95rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--card-bg);
+      color: var(--text);
+      outline: none;
+      transition: border-color .15s;
+    }
+
+    input[type="text"]:focus, textarea:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, .12);
+    }
+
+    textarea {
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+      font-size: .88rem;
+      line-height: 1.6;
+      min-height: 420px;
+      resize: vertical;
+    }
+
+    .field { margin-bottom: 1.25rem; }
+
+    .btn {
+      display: inline-block;
+      padding: .5rem 1rem;
+      font-size: .9rem;
+      border-radius: var(--radius);
+      text-decoration: none;
+      cursor: pointer;
+      border: none;
+      font-weight: 500;
+      transition: background .15s;
+    }
+
+    .btn-primary { background: var(--accent); color: #fff; }
+    .btn-primary:hover { background: var(--accent-hover); }
+    .btn-secondary { background: var(--border); color: var(--text); }
+    .btn-secondary:hover { background: #d0d0d0; }
+
+    .form-actions {
+      display: flex;
+      gap: .75rem;
+      align-items: center;
+      margin-top: .5rem;
+    }
+
+    .guide-link {
+      font-size: .85rem;
+      color: var(--accent);
+      text-decoration: none;
+      margin-left: auto;
+    }
+
+    .guide-link:hover { text-decoration: underline; }
+
+    .preview-area {
+      display: none;
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.25rem;
+      margin-top: 1rem;
+      font-size: .95rem;
+      line-height: 1.7;
+      white-space: pre-wrap;
+      font-family: inherit;
+    }
+
+    .preview-area.visible { display: block; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>{% if mode == 'create' %}Create New Skill{% else %}Edit: {{ skill.name }}{% endif %}</h1>
+
+    {% if errors %}
+    <div class="errors">
+      <ul>
+        {% for err in errors %}
+        <li>{{ err }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    <form method="post"
+          action="{% if mode == 'create' %}/skills{% else %}/skills/{{ skill.name }}/update{% endif %}">
+      {% if mode == 'create' %}
+      <div class="field">
+        <label for="name">Skill Name</label>
+        <input type="text" id="name" name="name" placeholder="e.g. data-engineering"
+               value="{{ skill.name if skill else '' }}" required />
+      </div>
+      {% endif %}
+
+      <div class="field">
+        <label for="content">Content (Markdown)</label>
+        <textarea id="content" name="content" placeholder="# Skill: Domain Name&#10;&#10;> Summary of this skill...">{{ skill.content if skill else '' }}</textarea>
+      </div>
+
+      <div class="form-actions">
+        <button type="submit" class="btn btn-primary">Save</button>
+        <button type="button" class="btn btn-secondary" onclick="togglePreview()">Preview</button>
+        <a class="btn btn-secondary" href="/skills">Cancel</a>
+        <a class="guide-link" href="/skills/guide" target="_blank">Authoring Guide</a>
+      </div>
+    </form>
+
+    <div id="preview" class="preview-area"></div>
+  </div>
+
+  <script>
+    function togglePreview() {
+      var preview = document.getElementById('preview');
+      var content = document.getElementById('content').value;
+      if (preview.classList.contains('visible')) {
+        preview.classList.remove('visible');
+      } else {
+        preview.textContent = content;
+        preview.classList.add('visible');
+      }
+    }
+  </script>
+</body>
+</html>

--- a/landing/app/templates/skill_view.html
+++ b/landing/app/templates/skill_view.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ skill_name }} — SUS Skills</title>
+  <style>
+    :root {
+      --bg: #f5f5f5;
+      --card-bg: #ffffff;
+      --text: #1a1a1a;
+      --muted: #666;
+      --accent: #2563eb;
+      --accent-hover: #1d4ed8;
+      --border: #e0e0e0;
+      --radius: 8px;
+      --danger: #dc2626;
+      --danger-hover: #b91c1c;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+      padding: 2rem;
+    }
+
+    .container {
+      max-width: 760px;
+      margin: 0 auto;
+    }
+
+    .top-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .top-bar h1 { font-size: 1.5rem; }
+
+    .top-actions {
+      display: flex;
+      gap: .5rem;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: .45rem .9rem;
+      font-size: .85rem;
+      border-radius: var(--radius);
+      text-decoration: none;
+      cursor: pointer;
+      border: none;
+      font-weight: 500;
+      transition: background .15s;
+    }
+
+    .btn-primary { background: var(--accent); color: #fff; }
+    .btn-primary:hover { background: var(--accent-hover); }
+    .btn-secondary { background: var(--border); color: var(--text); }
+    .btn-secondary:hover { background: #d0d0d0; }
+    .btn-danger { background: var(--danger); color: #fff; }
+    .btn-danger:hover { background: var(--danger-hover); }
+
+    .content-body {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.5rem 2rem;
+      line-height: 1.7;
+    }
+
+    .content-body h1 { font-size: 1.4rem; margin: 1rem 0 .5rem; }
+    .content-body h2 { font-size: 1.2rem; margin: 1.25rem 0 .5rem; }
+    .content-body h3 { font-size: 1.05rem; margin: 1rem 0 .4rem; }
+    .content-body p { margin-bottom: .75rem; }
+    .content-body ul, .content-body ol { margin: .5rem 0 .75rem 1.5rem; }
+    .content-body code {
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+      font-size: .88em;
+      background: #f0f0f0;
+      padding: .15em .35em;
+      border-radius: 3px;
+    }
+    .content-body pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      border-radius: var(--radius);
+      padding: 1rem 1.25rem;
+      overflow-x: auto;
+      margin: .75rem 0;
+      font-size: .85rem;
+      line-height: 1.5;
+    }
+    .content-body pre code {
+      background: none;
+      padding: 0;
+      color: inherit;
+    }
+    .content-body table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: .75rem 0;
+      font-size: .9rem;
+    }
+    .content-body th, .content-body td {
+      border: 1px solid var(--border);
+      padding: .45rem .65rem;
+      text-align: left;
+    }
+    .content-body th { background: #f9f9f9; font-weight: 600; }
+    .content-body blockquote {
+      border-left: 3px solid var(--accent);
+      padding-left: 1rem;
+      color: var(--muted);
+      margin: .75rem 0;
+    }
+    .content-body hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 1.25rem 0;
+    }
+
+    .back-link {
+      display: inline-block;
+      margin-top: 1.5rem;
+      font-size: .9rem;
+      color: var(--accent);
+      text-decoration: none;
+    }
+
+    .back-link:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="top-bar">
+      <h1>{{ skill_name }}</h1>
+      <div class="top-actions">
+        {% if not is_guide %}
+        <a class="btn btn-primary" href="/skills/{{ skill_name }}/edit">Edit</a>
+        {% if skill_name.upper() != "AUTHORING" %}
+        <form method="post" action="/skills/{{ skill_name }}/delete" style="display:inline"
+              onsubmit="return confirm('Delete skill {{ skill_name }}?');">
+          <input type="hidden" name="_method" value="DELETE" />
+          <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+        {% endif %}
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="content-body">
+      {{ content_html | safe }}
+    </div>
+
+    <a class="back-link" href="/skills">Back to skills list</a>
+  </div>
+</body>
+</html>

--- a/landing/app/templates/skills_list.html
+++ b/landing/app/templates/skills_list.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Guidance Skills — SUS</title>
+  <style>
+    :root {
+      --bg: #f5f5f5;
+      --card-bg: #ffffff;
+      --text: #1a1a1a;
+      --muted: #666;
+      --accent: #2563eb;
+      --accent-hover: #1d4ed8;
+      --border: #e0e0e0;
+      --radius: 8px;
+      --danger: #dc2626;
+      --danger-hover: #b91c1c;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+      padding: 2rem;
+    }
+
+    header {
+      max-width: 960px;
+      margin: 0 auto 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    header h1 { font-size: 1.5rem; }
+
+    .header-actions {
+      display: flex;
+      gap: .75rem;
+      align-items: center;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: .45rem .9rem;
+      font-size: .85rem;
+      border-radius: var(--radius);
+      text-decoration: none;
+      cursor: pointer;
+      border: none;
+      font-weight: 500;
+      transition: background .15s;
+    }
+
+    .btn-primary { background: var(--accent); color: #fff; }
+    .btn-primary:hover { background: var(--accent-hover); }
+    .btn-secondary { background: var(--border); color: var(--text); }
+    .btn-secondary:hover { background: #d0d0d0; }
+    .btn-danger { background: var(--danger); color: #fff; }
+    .btn-danger:hover { background: var(--danger-hover); }
+    .btn-sm { padding: .3rem .65rem; font-size: .8rem; }
+
+    .skills-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 1.25rem;
+      max-width: 960px;
+      margin: 0 auto;
+    }
+
+    .card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: .5rem;
+    }
+
+    .card h2 { font-size: 1.1rem; }
+    .card .description { flex: 1; font-size: .9rem; color: var(--muted); }
+
+    .card .actions {
+      display: flex;
+      gap: .5rem;
+      margin-top: .75rem;
+      flex-wrap: wrap;
+    }
+
+    .sub-links {
+      max-width: 960px;
+      margin: 1.5rem auto 0;
+      font-size: .9rem;
+    }
+
+    .sub-links a {
+      color: var(--accent);
+      text-decoration: none;
+      margin-right: 1.5rem;
+    }
+
+    .sub-links a:hover { text-decoration: underline; }
+
+    .empty {
+      max-width: 960px;
+      margin: 0 auto;
+      text-align: center;
+      color: var(--muted);
+      padding: 3rem 0;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Guidance Skills</h1>
+    <div class="header-actions">
+      <a class="btn btn-secondary" href="/skills/guide">Authoring Guide</a>
+      <a class="btn btn-primary" href="/skills/new">Create New Skill</a>
+    </div>
+  </header>
+
+  <section class="skills-grid">
+    {% if skills %}
+    {% for skill in skills %}
+    <div class="card">
+      <h2>{{ skill.name }}</h2>
+      <div class="description">{{ skill.description or "No description" }}</div>
+      <div class="actions">
+        <a class="btn btn-primary btn-sm" href="/skills/{{ skill.name }}">View</a>
+        <a class="btn btn-secondary btn-sm" href="/skills/{{ skill.name }}/edit">Edit</a>
+        {% if skill.name.upper() != "AUTHORING" %}
+        <form method="post" action="/skills/{{ skill.name }}/delete" style="display:inline"
+              onsubmit="return confirm('Delete skill {{ skill.name }}?');">
+          <input type="hidden" name="_method" value="DELETE" />
+          <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+        </form>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+    {% else %}
+    <div class="empty" style="grid-column:1/-1">
+      <p>No skills found. Create your first guidance skill!</p>
+    </div>
+    {% endif %}
+  </section>
+
+  <div class="sub-links">
+    <a href="/">Back to catalog</a>
+  </div>
+</body>
+</html>

--- a/landing/requirements.txt
+++ b/landing/requirements.txt
@@ -5,3 +5,4 @@ websockets
 jinja2
 httpx
 aiosqlite
+markdown


### PR DESCRIPTION
## Summary
- `landing/app/skills.py` — `SkillsManager` for CRUD on skill Markdown files with validation
- `landing/app/routes/skills.py` — Full skills router: list, view (rendered Markdown), create, edit, delete, authoring guide
- Templates: `skills_list.html`, `skill_editor.html`, `skill_view.html`
- AUTHORING.md is protected from deletion
- Skills link added to landing page header
- Added `markdown` dependency for rendering

## Test plan
- [ ] `/skills` lists all existing skills
- [ ] `/skills/new` shows create form, saves valid skill
- [ ] `/skills/{name}` renders Markdown as HTML
- [ ] `/skills/{name}/edit` allows editing
- [ ] Delete works (except for AUTHORING.md)
- [ ] Validation catches missing title heading

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)