### PR TITLE
Add API key setup UI with K8s secret management

### DIFF
--- a/charts/sus/templates/rbac.yaml
+++ b/charts/sus/templates/rbac.yaml
@@ -9,6 +9,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "services"]
     verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/sus/values.yaml
+++ b/charts/sus/values.yaml
@@ -10,7 +10,7 @@ landing:
   image:
     repository: localhost:5050/sus-landing
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   replicaCount: 1
   port: 8000
   serviceAccount:

--- a/landing/app/api_key.py
+++ b/landing/app/api_key.py
@@ -1,0 +1,80 @@
+"""Manage the Anthropic API key as a Kubernetes Secret."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+logger = logging.getLogger(__name__)
+
+SECRET_NAME = "sus-anthropic-api-key"
+SECRET_KEY = "ANTHROPIC_API_KEY"
+
+
+class APIKeyManager:
+    """Check, set, and read the Anthropic API key stored as a K8s Secret."""
+
+    def __init__(self) -> None:
+        try:
+            config.load_incluster_config()
+        except config.ConfigException:
+            config.load_kube_config()
+
+        self._core = client.CoreV1Api()
+        self._namespace = os.environ.get("SUS_WORKLOADS_NAMESPACE", "sus-workloads")
+
+    def is_configured(self) -> bool:
+        """Return True if the API key secret exists."""
+        try:
+            self._core.read_namespaced_secret(SECRET_NAME, self._namespace)
+            return True
+        except ApiException as exc:
+            if exc.status == 404:
+                return False
+            raise
+
+    def get_key(self) -> str | None:
+        """Read the API key from the secret. Returns None if not set."""
+        try:
+            secret = self._core.read_namespaced_secret(SECRET_NAME, self._namespace)
+            if secret.data and SECRET_KEY in secret.data:
+                import base64
+                return base64.b64decode(secret.data[SECRET_KEY]).decode()
+        except ApiException as exc:
+            if exc.status == 404:
+                return None
+            raise
+        return None
+
+    def set_key(self, api_key: str) -> None:
+        """Create or update the API key secret."""
+        secret = client.V1Secret(
+            metadata=client.V1ObjectMeta(
+                name=SECRET_NAME,
+                namespace=self._namespace,
+            ),
+            string_data={SECRET_KEY: api_key},
+            type="Opaque",
+        )
+        try:
+            self._core.read_namespaced_secret(SECRET_NAME, self._namespace)
+            # Secret exists — update it.
+            self._core.replace_namespaced_secret(SECRET_NAME, self._namespace, secret)
+            logger.info("Updated API key secret in %s", self._namespace)
+        except ApiException as exc:
+            if exc.status == 404:
+                self._core.create_namespaced_secret(self._namespace, secret)
+                logger.info("Created API key secret in %s", self._namespace)
+            else:
+                raise
+
+    def delete_key(self) -> None:
+        """Delete the API key secret."""
+        try:
+            self._core.delete_namespaced_secret(SECRET_NAME, self._namespace)
+        except ApiException as exc:
+            if exc.status != 404:
+                raise

--- a/landing/app/main.py
+++ b/landing/app/main.py
@@ -24,6 +24,7 @@ from .routes.mcp import router as mcp_router
 from .routes.run import router as run_router
 from .routes.sessions import router as sessions_router
 from .routes.skills import router as skills_router
+from .routes.setup import router as setup_router
 from .routes.versions import router as versions_router
 from .sessions import SessionStore
 
@@ -38,6 +39,7 @@ app.include_router(build_router)
 app.include_router(mcp_router)
 app.include_router(run_router)
 app.include_router(sessions_router)
+app.include_router(setup_router)
 app.include_router(skills_router)
 app.include_router(versions_router)
 
@@ -143,6 +145,15 @@ async def index(
         tags=tags or None,
     )
     available_tags = all_tags()
+
+    # Check if API key is configured for the setup banner.
+    api_key_configured = False
+    try:
+        from .api_key import APIKeyManager
+        api_key_configured = APIKeyManager().is_configured()
+    except Exception:
+        pass
+
     return templates.TemplateResponse(
         request,
         "index.html",
@@ -152,5 +163,6 @@ async def index(
             "available_tags": available_tags,
             "active_tags": tags or [],
             "query": q or "",
+            "api_key_configured": api_key_configured,
         },
     )

--- a/landing/app/pods.py
+++ b/landing/app/pods.py
@@ -77,6 +77,16 @@ class BuildPodManager:
                             client.V1EnvVar(name="GIT_REPO_URL", value=f"https://github.com/sus/{app_slug}.git"),
                             client.V1EnvVar(name="USER_ID", value=user_id),
                             client.V1EnvVar(name="APP_SLUG", value=app_slug),
+                            client.V1EnvVar(
+                                name="ANTHROPIC_API_KEY",
+                                value_from=client.V1EnvVarSource(
+                                    secret_key_ref=client.V1SecretKeySelector(
+                                        name="sus-anthropic-api-key",
+                                        key="ANTHROPIC_API_KEY",
+                                        optional=True,
+                                    ),
+                                ),
+                            ),
                         ]
                         + (
                             [client.V1EnvVar(name="SUS_MCP_CONFIG", value=json.dumps(mcp_config))]

--- a/landing/app/routes/setup.py
+++ b/landing/app/routes/setup.py
@@ -1,0 +1,96 @@
+"""Setup routes — API key configuration and onboarding."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from ..api_key import APIKeyManager
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/setup")
+
+_templates_dir = Path(__file__).resolve().parent.parent / "templates"
+_templates = Jinja2Templates(directory=str(_templates_dir))
+
+_api_key_mgr: APIKeyManager | None = None
+
+
+def _get_api_key_mgr() -> APIKeyManager:
+    global _api_key_mgr
+    if _api_key_mgr is None:
+        _api_key_mgr = APIKeyManager()
+    return _api_key_mgr
+
+
+@router.get("", response_class=HTMLResponse)
+async def setup_page(request: Request) -> HTMLResponse:
+    """Render the setup page."""
+    try:
+        mgr = _get_api_key_mgr()
+        configured = mgr.is_configured()
+    except Exception:
+        logger.exception("Failed to check API key status")
+        configured = False
+
+    return _templates.TemplateResponse(
+        request,
+        "setup.html",
+        context={"configured": configured},
+    )
+
+
+@router.post("/api-key", response_model=None)
+async def set_api_key(
+    request: Request,
+    api_key: str = Form(...),
+):
+    """Save the Anthropic API key as a Kubernetes secret."""
+    key = api_key.strip()
+    if not key.startswith("sk-ant-"):
+        return _templates.TemplateResponse(
+            request,
+            "setup.html",
+            context={"configured": False, "error": "Invalid API key. It should start with sk-ant-"},
+        )
+
+    try:
+        mgr = _get_api_key_mgr()
+        mgr.set_key(key)
+    except Exception:
+        logger.exception("Failed to save API key")
+        return _templates.TemplateResponse(
+            request,
+            "setup.html",
+            context={"configured": False, "error": "Failed to save API key. Check cluster permissions."},
+        )
+
+    return RedirectResponse(url="/", status_code=303)
+
+
+@router.get("/api/status")
+async def api_key_status() -> JSONResponse:
+    """Check if the API key is configured."""
+    try:
+        mgr = _get_api_key_mgr()
+        return JSONResponse({"configured": mgr.is_configured()})
+    except Exception:
+        return JSONResponse({"configured": False})
+
+
+@router.post("/api-key/delete")
+async def delete_api_key() -> JSONResponse:
+    """Delete the API key secret."""
+    try:
+        mgr = _get_api_key_mgr()
+        mgr.delete_key()
+        return JSONResponse({"status": "deleted"})
+    except Exception:
+        logger.exception("Failed to delete API key")
+        return JSONResponse({"status": "error"}, status_code=500)

--- a/landing/app/templates/index.html
+++ b/landing/app/templates/index.html
@@ -176,8 +176,14 @@
 <body>
   <header>
     <h1>SUS — Single Use Software</h1>
-    <p>Welcome, {{ identity.display_name }}. Browse, build, or run applications. <a href="/skills" style="color: var(--accent); text-decoration: none; font-size: .85rem; margin-left: .5rem;">Skills</a> <a href="/analytics" style="color: var(--accent); text-decoration: none; font-size: .85rem; margin-left: .5rem;">Analytics</a></p>
+    <p>Welcome, {{ identity.display_name }}. Browse, build, or run applications. <a href="/skills" style="color: var(--accent); text-decoration: none; font-size: .85rem; margin-left: .5rem;">Skills</a> <a href="/analytics" style="color: var(--accent); text-decoration: none; font-size: .85rem; margin-left: .5rem;">Analytics</a> <a href="/setup" style="color: var(--accent); text-decoration: none; font-size: .85rem; margin-left: .5rem;">Setup</a></p>
   </header>
+
+  {% if not api_key_configured %}
+  <div style="max-width: 960px; margin: 0 auto 1.5rem; padding: 1rem 1.25rem; background: #fef3c7; border: 1px solid #fcd34d; border-radius: var(--radius); display: flex; align-items: center; justify-content: space-between;">
+    <span style="font-size: .9rem; color: #92400e;">Build mode requires an Anthropic API key. <a href="/setup" style="color: #92400e; font-weight: 600;">Configure it now</a> to start building apps.</span>
+  </div>
+  {% endif %}
 
   <!-- Search bar -->
   <div class="search-section">

--- a/landing/app/templates/setup.html
+++ b/landing/app/templates/setup.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SUS — Setup</title>
+  <style>
+    :root {
+      --bg: #f5f5f5;
+      --card-bg: #ffffff;
+      --text: #1a1a1a;
+      --muted: #666;
+      --accent: #2563eb;
+      --accent-hover: #1d4ed8;
+      --border: #e0e0e0;
+      --radius: 8px;
+      --danger: #dc2626;
+      --success: #16a34a;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+      display: flex;
+      justify-content: center;
+      padding: 3rem 1rem;
+    }
+
+    .setup-card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 2.5rem;
+      max-width: 520px;
+      width: 100%;
+    }
+
+    .setup-card h1 {
+      font-size: 1.5rem;
+      margin-bottom: .25rem;
+    }
+
+    .setup-card .subtitle {
+      color: var(--muted);
+      margin-bottom: 2rem;
+    }
+
+    .status {
+      display: flex;
+      align-items: center;
+      gap: .5rem;
+      padding: .75rem 1rem;
+      border-radius: var(--radius);
+      margin-bottom: 1.5rem;
+      font-size: .9rem;
+    }
+
+    .status.configured {
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      color: var(--success);
+    }
+
+    .status.not-configured {
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      color: var(--danger);
+    }
+
+    .status .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .status.configured .dot { background: var(--success); }
+    .status.not-configured .dot { background: var(--danger); }
+
+    label {
+      display: block;
+      font-weight: 500;
+      margin-bottom: .5rem;
+      font-size: .9rem;
+    }
+
+    .hint {
+      color: var(--muted);
+      font-size: .8rem;
+      margin-bottom: .75rem;
+    }
+
+    input[type="password"] {
+      width: 100%;
+      padding: .6rem .75rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: .95rem;
+      font-family: monospace;
+      margin-bottom: 1rem;
+    }
+
+    input[type="password"]:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+
+    .btn {
+      display: inline-block;
+      padding: .6rem 1.25rem;
+      font-size: .9rem;
+      border-radius: var(--radius);
+      text-decoration: none;
+      cursor: pointer;
+      border: none;
+      font-weight: 500;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+    }
+    .btn-primary:hover { background: var(--accent-hover); }
+
+    .btn-link {
+      background: none;
+      color: var(--muted);
+      padding: .6rem 0;
+      margin-left: 1rem;
+    }
+    .btn-link:hover { color: var(--text); }
+
+    .actions {
+      display: flex;
+      align-items: center;
+    }
+
+    .error {
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      color: var(--danger);
+      padding: .75rem 1rem;
+      border-radius: var(--radius);
+      margin-bottom: 1rem;
+      font-size: .9rem;
+    }
+
+    .info {
+      margin-top: 2rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--border);
+    }
+
+    .info h3 {
+      font-size: .95rem;
+      margin-bottom: .5rem;
+    }
+
+    .info p {
+      color: var(--muted);
+      font-size: .85rem;
+      margin-bottom: .5rem;
+    }
+
+    code {
+      background: #f1f5f9;
+      padding: .15rem .35rem;
+      border-radius: 3px;
+      font-size: .85rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="setup-card">
+    <h1>SUS Setup</h1>
+    <p class="subtitle">Configure your Anthropic API key to enable build mode.</p>
+
+    {% if configured %}
+    <div class="status configured">
+      <span class="dot"></span>
+      API key is configured. Build mode is ready.
+    </div>
+    {% else %}
+    <div class="status not-configured">
+      <span class="dot"></span>
+      No API key configured. Build mode requires an Anthropic API key.
+    </div>
+    {% endif %}
+
+    {% if error %}
+    <div class="error">{{ error }}</div>
+    {% endif %}
+
+    <form method="post" action="/setup/api-key">
+      <label for="api_key">
+        {% if configured %}Update{% else %}Enter{% endif %} Anthropic API Key
+      </label>
+      <p class="hint">
+        Get your key at <a href="https://console.anthropic.com/settings/keys" target="_blank">console.anthropic.com</a>.
+        It will be stored as a Kubernetes secret.
+      </p>
+      <input type="password" id="api_key" name="api_key" placeholder="sk-ant-..." required />
+      <div class="actions">
+        <button type="submit" class="btn btn-primary">
+          {% if configured %}Update Key{% else %}Save Key{% endif %}
+        </button>
+        <a href="/" class="btn btn-link">
+          {% if configured %}Back to catalog{% else %}Skip for now{% endif %}
+        </a>
+      </div>
+    </form>
+
+    <div class="info">
+      <h3>Power users</h3>
+      <p>
+        You can also set the key directly via kubectl:
+      </p>
+      <p>
+        <code>kubectl create secret generic sus-anthropic-api-key -n sus-workloads --from-literal=ANTHROPIC_API_KEY=sk-ant-...</code>
+      </p>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Setup page at `/setup` where users can enter their Anthropic API key
- Key is stored as a Kubernetes Secret (`sus-anthropic-api-key`) in the workloads namespace
- Build pods automatically receive the key via `secretKeyRef` env var
- Landing page shows a yellow banner when no key is configured
- Power users can skip the UI and set the key via `kubectl`
- RBAC updated to allow the landing page SA to manage secrets

## Test plan
- [ ] `/setup` renders the setup page
- [ ] Entering a valid key (sk-ant-...) saves it as a K8s secret
- [ ] Invalid keys show an error message
- [ ] Banner appears on catalog page when key is not configured
- [ ] Banner disappears after key is saved
- [ ] `/setup/api/status` returns correct configured status

🤖 Generated with [Claude Code](https://claude.com/claude-code)