### PR TITLE
Suppress Claude Code welcome screen and auto-update prompts

### DIFF
--- a/build-pod/CLAUDE.md
+++ b/build-pod/CLAUDE.md
@@ -2,6 +2,19 @@
 
 You are running inside a SUS (Single Use Software) build pod. Follow these rules strictly.
 
+## Environment Pre-Configuration
+
+This build pod is already fully configured. Do NOT prompt the user for any
+setup, model selection, welcome flow, or permission grants. The entrypoint
+handles all of the following automatically:
+
+- **Model** — pre-selected via `--model` flag (no selection prompt).
+- **Permissions** — bypassed via `--dangerously-skip-permissions` (sandbox only).
+- **Auto-updater** — disabled via `DISABLE_AUTOUPDATER=1`.
+- **Settings** — written to `~/.claude/settings.json` at image build time.
+
+Jump straight into assisting the user with their task.
+
 ## Default Stack
 
 - **Python + HTMX** unless the user explicitly requests otherwise.

--- a/build-pod/Dockerfile
+++ b/build-pod/Dockerfile
@@ -40,6 +40,15 @@ RUN chmod 444 /repo/claude/skills/*.md
 # Create non-root user for Claude Code (it refuses to run as root)
 RUN useradd -m -s /bin/bash sus && chown -R sus:sus /repo
 
+# Pre-configure Claude Code to suppress welcome screen, model banners, and
+# update notices so users land straight in the session.
+RUN mkdir -p /home/sus/.claude && \
+    echo '{"autoUpdaterStatus":"disabled"}' > /home/sus/.claude/settings.json && \
+    chown -R sus:sus /home/sus/.claude
+
+# Disable the Claude Code auto-updater at the environment level
+ENV DISABLE_AUTOUPDATER=1
+
 WORKDIR /repo
 
 # Copy and set up entrypoint

--- a/build-pod/entrypoint.sh
+++ b/build-pod/entrypoint.sh
@@ -69,5 +69,13 @@ _autosave_loop &
 # --- Start Claude Code CLI via ttyd ---------------------------------------
 # ttyd exposes the Claude Code CLI as a WebSocket terminal on port 8080.
 # The landing page proxies the browser's xterm.js to this WebSocket.
+#
+# Flags:
+#   --dangerously-skip-permissions  — pre-approved sandbox, no permission prompts
+#   --model sonnet                  — pre-select model to skip model-selection banner
+#   DISABLE_AUTOUPDATER=1           — suppress update notices (set in Dockerfile + below)
 
-exec ttyd --port 8080 --writable --base-path / claude --dangerously-skip-permissions
+export DISABLE_AUTOUPDATER=1
+
+exec ttyd --port 8080 --writable --base-path / \
+    claude --dangerously-skip-permissions --model sonnet


### PR DESCRIPTION
## Summary
- Pre-configure `~/.claude/settings.json` with `autoUpdaterStatus: disabled`
- Set `DISABLE_AUTOUPDATER=1` env var
- Add `--model sonnet` flag to skip model selection prompt
- Updated CLAUDE.md to tell Claude not to prompt for setup

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)