### PR TITLE
Auto-start app on port 3000 and auto-refresh preview pane

### DIFF
--- a/build-pod/CLAUDE.md
+++ b/build-pod/CLAUDE.md
@@ -21,6 +21,23 @@ You manage all git operations. The user never touches git directly.
 | User clicks **Publish** | Open a PR, run auditor, auto-merge to main |
 | Merge conflict on publish | Resolve automatically; notify user in plain English if unresolvable |
 
+## Auto-Runner (port 3000)
+
+A background runner process in the entrypoint watches `/repo` every 5 seconds
+and automatically starts the appropriate server on **port 3000**:
+
+- `requirements.txt` with `fastapi`/`uvicorn` -> `uvicorn main:app` with `--reload`
+- `package.json` -> `npm start` (or `node server.js`)
+- `index.html` -> `python3 -m http.server 3000`
+
+**You do NOT need to manually start the server.** Just create the application
+files (e.g., `main.py`, `requirements.txt`) and the runner will detect them and
+start serving automatically. The preview pane in the browser will pick it up.
+
+If the stack changes (e.g., switching from a static site to FastAPI), the runner
+kills the old server and starts the correct one. If the server crashes, the
+runner restarts it automatically.
+
 ## Sub-Agents
 
 Sub-agent skill definitions are located in `/repo/claude/skills/`. Load them at

--- a/build-pod/entrypoint.sh
+++ b/build-pod/entrypoint.sh
@@ -66,6 +66,103 @@ _autosave_loop() {
 
 _autosave_loop &
 
+# --- Runner: auto-start app on port 3000 ---------------------------------
+# Background watcher that detects servable content in /repo and starts the
+# appropriate server process.  Checks every 5 seconds.
+
+SERVER_PID=""
+SERVER_TYPE=""
+
+_kill_server() {
+    if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    SERVER_PID=""
+    SERVER_TYPE=""
+}
+
+_start_server() {
+    local new_type="$1"
+
+    # If the stack changed, kill the old server first
+    if [ -n "$SERVER_TYPE" ] && [ "$SERVER_TYPE" != "$new_type" ]; then
+        _kill_server
+    fi
+
+    # Already running with the right type — nothing to do
+    if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        return
+    fi
+
+    SERVER_TYPE="$new_type"
+
+    case "$new_type" in
+        python)
+            cd /repo
+            pip install -q -r requirements.txt 2>/dev/null || true
+            uvicorn main:app --host 0.0.0.0 --port 3000 --reload &
+            SERVER_PID=$!
+            ;;
+        node)
+            cd /repo
+            npm install --silent 2>/dev/null || true
+            if grep -q '"start"' /repo/package.json 2>/dev/null; then
+                npm start &
+            else
+                node server.js &
+            fi
+            SERVER_PID=$!
+            ;;
+        static)
+            cd /repo
+            python3 -m http.server 3000 &
+            SERVER_PID=$!
+            ;;
+    esac
+}
+
+_runner_loop() {
+    while true; do
+        sleep 5
+
+        # Determine what kind of project exists in /repo
+        detected=""
+        if [ -f /repo/requirements.txt ]; then
+            if grep -qiE 'fastapi|uvicorn' /repo/requirements.txt 2>/dev/null; then
+                detected="python"
+            fi
+        fi
+
+        if [ -z "$detected" ] && [ -f /repo/package.json ]; then
+            detected="node"
+        fi
+
+        if [ -z "$detected" ] && [ -f /repo/index.html ]; then
+            detected="static"
+        fi
+
+        if [ -z "$detected" ]; then
+            continue
+        fi
+
+        # If stack changed, kill old server
+        if [ -n "$SERVER_TYPE" ] && [ "$SERVER_TYPE" != "$detected" ]; then
+            _kill_server
+        fi
+
+        # Restart if the server died
+        if [ -n "$SERVER_PID" ] && ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            SERVER_PID=""
+            SERVER_TYPE=""
+        fi
+
+        _start_server "$detected"
+    done
+}
+
+_runner_loop &
+
 # --- Start Claude Code CLI via ttyd ---------------------------------------
 # ttyd exposes the Claude Code CLI as a WebSocket terminal on port 8080.
 # The landing page proxies the browser's xterm.js to this WebSocket.

--- a/landing/app/templates/build.html
+++ b/landing/app/templates/build.html
@@ -126,12 +126,32 @@
     }
 
     .preview-pane-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
       padding: 6px 12px;
       font-size: 12px;
       color: var(--text-secondary);
       background: var(--bg-secondary);
       border-bottom: 1px solid var(--border-color);
       user-select: none;
+    }
+
+    .btn-refresh {
+      padding: 2px 8px;
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--text-secondary);
+      background: transparent;
+      border: 1px solid var(--border-color);
+      border-radius: 4px;
+      cursor: pointer;
+      transition: color 0.15s, border-color 0.15s;
+    }
+
+    .btn-refresh:hover {
+      color: var(--accent);
+      border-color: var(--accent);
     }
 
     #preview-iframe {
@@ -172,7 +192,10 @@
     </div>
     <div class="divider" id="divider"></div>
     <div class="preview-pane" id="preview-pane">
-      <div class="preview-pane-header">Preview</div>
+      <div class="preview-pane-header">
+        <span>Preview</span>
+        <button class="btn-refresh" id="btn-refresh" onclick="refreshPreview()">Refresh</button>
+      </div>
       <iframe id="preview-iframe"
               src="/build/{{ team }}/{{ app_slug }}/preview/?pod_ip={{ pod_ip }}"></iframe>
     </div>
@@ -236,6 +259,73 @@
       } finally {
         btn.disabled = false;
       }
+    }
+
+    // --- Preview auto-refresh ---
+    // Periodically reload the preview iframe until it loads successfully.
+    let previewLoaded = false;
+    let previewTimer = null;
+
+    function refreshPreview() {
+      const iframe = document.getElementById('preview-iframe');
+      if (iframe) {
+        iframe.src = iframe.src;
+      }
+    }
+
+    function checkPreview() {
+      const iframe = document.getElementById('preview-iframe');
+      if (!iframe) return;
+
+      try {
+        // Try to access iframe content — if cross-origin, this throws.
+        // A successful load with actual content means the app is up.
+        const doc = iframe.contentDocument || iframe.contentWindow.document;
+        const body = doc && doc.body;
+        if (body) {
+          const text = body.innerText || '';
+          // Check for common error indicators
+          if (text.includes('Bad Gateway') ||
+              text.includes('502') ||
+              text.includes('503') ||
+              text.includes('Connection refused')) {
+            // Still erroring — reload
+            refreshPreview();
+          } else if (text.trim().length > 0) {
+            // Content loaded successfully — stop polling
+            previewLoaded = true;
+            if (previewTimer) {
+              clearInterval(previewTimer);
+              previewTimer = null;
+            }
+          }
+        }
+      } catch (e) {
+        // Cross-origin: we can't inspect content, but the iframe loaded
+        // something. If it were a gateway error from our own proxy it would
+        // be same-origin, so a cross-origin load likely means success.
+        previewLoaded = true;
+        if (previewTimer) {
+          clearInterval(previewTimer);
+          previewTimer = null;
+        }
+      }
+    }
+
+    // Start polling every 5 seconds
+    previewTimer = setInterval(() => {
+      if (!previewLoaded) {
+        checkPreview();
+      }
+    }, 5000);
+
+    // Also check once after initial load
+    const previewIframe = document.getElementById('preview-iframe');
+    if (previewIframe) {
+      previewIframe.addEventListener('load', () => {
+        // Small delay to let content render
+        setTimeout(checkPreview, 500);
+      });
     }
 
     async function doPublish() {


### PR DESCRIPTION
## Summary
- Added runner loop to build pod entrypoint that watches for servable content every 5s
  - Detects Python (FastAPI/uvicorn), Node.js, or static HTML
  - Auto-starts appropriate server on port 3000
  - Restarts on crash, kills/restarts on stack change
- Updated CLAUDE.md to inform Claude the runner handles server startup
- Preview pane auto-refreshes every 5s while showing Bad Gateway
- Added manual "Refresh" button in preview pane header

Closes #44
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)