### PR TITLE
Wire up end-to-end publish and run flow (MVP)

### DIFF
--- a/landing/app/git_workflow.py
+++ b/landing/app/git_workflow.py
@@ -151,34 +151,40 @@ class GitWorkflowManager:
         return {"status": "save_requested", "branch": branch}
 
     def publish(self, user_id: str, team: str, app_slug: str) -> dict:
-        """Signal the build pod that a publish (PR creation) was requested.
+        """Publish the app — register the build pod as the run target.
 
-        The actual PR is created by Claude Code inside the pod.
-
-        Returns status information including the branch name.
+        For the MVP, we skip building a separate container image and instead
+        proxy run-mode traffic to the existing build pod's port 3000.
         """
         session = self._sessions.get(user_id, app_slug)
         if session is None:
             return {"status": "error", "detail": "no active session"}
 
         branch = session["branch"]
-        # TODO: write a marker file / send a signal to the build pod so Claude
-        # Code picks up the publish request.
-        logger.info(
-            "Publish requested for %s/%s on branch %s",
-            user_id,
-            app_slug,
-            branch,
+        pod_name = session["pod_name"]
+
+        # Get the build pod's IP so we can proxy run traffic to it.
+        pod_info = self._pods.get_build_pod(pod_name)
+        pod_ip = pod_info.get("pod_ip") if pod_info else None
+
+        if not pod_ip:
+            return {"status": "error", "detail": "build pod not running"}
+
+        # Register the build pod as the run target.
+        from .published_apps import PublishedAppStore
+        store = PublishedAppStore()
+        store.publish(
+            team=team,
+            app_slug=app_slug,
+            pod_ip=pod_ip,
+            pod_name=pod_name,
+            published_by=user_id,
         )
 
-        # If a publisher is configured, also create/update the run pod.
-        publish_result = None
-        if self._publisher is not None:
-            try:
-                publish_result = self._publisher.publish_app(team=team, app_slug=app_slug)
-                logger.info("Run pod published: %s", publish_result)
-            except Exception:
-                logger.exception("Failed to publish run pod for %s/%s", team, app_slug)
+        logger.info(
+            "Published %s/%s — proxying run to build pod %s (%s)",
+            team, app_slug, pod_name, pod_ip,
+        )
 
         return {
             "status": "publish_requested",

--- a/landing/app/published_apps.py
+++ b/landing/app/published_apps.py
@@ -1,0 +1,67 @@
+"""Track published apps and their serving endpoints."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+
+
+class PublishedAppStore:
+    """SQLite-backed store mapping published apps to their serving pod IP."""
+
+    def __init__(self, db_path: str = "published_apps.db") -> None:
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS published_apps (
+                team      TEXT NOT NULL,
+                app_slug  TEXT NOT NULL,
+                pod_ip    TEXT NOT NULL,
+                pod_name  TEXT NOT NULL,
+                published_by TEXT NOT NULL DEFAULT 'anonymous',
+                published_at TEXT NOT NULL,
+                PRIMARY KEY (team, app_slug)
+            )
+            """
+        )
+        self._conn.commit()
+
+    def publish(self, team: str, app_slug: str, pod_ip: str, pod_name: str, published_by: str = "anonymous") -> None:
+        """Register or update a published app's serving endpoint."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            """
+            INSERT INTO published_apps (team, app_slug, pod_ip, pod_name, published_by, published_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT (team, app_slug) DO UPDATE SET
+                pod_ip = excluded.pod_ip,
+                pod_name = excluded.pod_name,
+                published_by = excluded.published_by,
+                published_at = excluded.published_at
+            """,
+            (team, app_slug, pod_ip, pod_name, published_by, now),
+        )
+        self._conn.commit()
+
+    def get(self, team: str, app_slug: str) -> dict | None:
+        """Look up a published app's serving endpoint."""
+        row = self._conn.execute(
+            "SELECT * FROM published_apps WHERE team = ? AND app_slug = ?",
+            (team, app_slug),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def delete(self, team: str, app_slug: str) -> None:
+        """Remove a published app."""
+        self._conn.execute(
+            "DELETE FROM published_apps WHERE team = ? AND app_slug = ?",
+            (team, app_slug),
+        )
+        self._conn.commit()
+
+    def list_all(self) -> list[dict]:
+        """List all published apps."""
+        rows = self._conn.execute("SELECT * FROM published_apps").fetchall()
+        return [dict(r) for r in rows]

--- a/landing/app/routes/run.py
+++ b/landing/app/routes/run.py
@@ -11,6 +11,7 @@ from fastapi.responses import HTMLResponse, Response
 from fastapi.templating import Jinja2Templates
 
 from ..proxy import http_proxy
+from ..published_apps import PublishedAppStore
 from ..run_pods import RunPodManager
 
 logger = logging.getLogger(__name__)
@@ -25,14 +26,21 @@ _templates = Jinja2Templates(directory=str(_templates_dir))
 # ---------------------------------------------------------------------------
 
 _run_pod_mgr: Optional[RunPodManager] = None
+_published_store: Optional[PublishedAppStore] = None
 
 
 def _get_run_pod_mgr() -> RunPodManager:
-    """Return the RunPodManager, creating it on first call."""
-    global _run_pod_mgr  # noqa: PLW0603
+    global _run_pod_mgr
     if _run_pod_mgr is None:
         _run_pod_mgr = RunPodManager()
     return _run_pod_mgr
+
+
+def _get_published_store() -> PublishedAppStore:
+    global _published_store
+    if _published_store is None:
+        _published_store = PublishedAppStore()
+    return _published_store
 
 
 # ---------------------------------------------------------------------------
@@ -69,27 +77,42 @@ async def run_proxy(
     app_slug: str,
     path: str,
 ) -> Response:
-    """Proxy HTTP requests to the run pod's app server.
+    """Proxy HTTP requests to the published app.
 
-    Looks up the run pod by team/app labels and forwards traffic to port 3000.
-    Returns 503 if no run pod is available.
+    First checks the published apps store (MVP: proxies to the build pod).
+    Falls back to looking for a dedicated run pod by labels.
+    Returns 503 if no serving endpoint is available.
     """
-    try:
-        mgr = _get_run_pod_mgr()
-        pod_info = mgr.find_run_pod(team, app_slug)
-    except Exception:
-        logger.exception("Failed to look up run pod for %s/%s", team, app_slug)
-        return Response(content="Service Unavailable", status_code=503)
+    pod_ip = None
 
-    if pod_info is None or not pod_info.get("pod_ip"):
+    # Check published apps store first (MVP: build pod as run target).
+    try:
+        store = _get_published_store()
+        published = store.get(team, app_slug)
+        if published:
+            pod_ip = published.get("pod_ip")
+    except Exception:
+        logger.exception("Failed to check published store for %s/%s", team, app_slug)
+
+    # Fall back to dedicated run pod lookup.
+    if not pod_ip:
+        try:
+            mgr = _get_run_pod_mgr()
+            pod_info = mgr.find_run_pod(team, app_slug)
+            if pod_info:
+                pod_ip = pod_info.get("pod_ip")
+        except Exception:
+            logger.exception("Failed to look up run pod for %s/%s", team, app_slug)
+
+    if not pod_ip:
         return Response(
-            content="No run pod available for this application.",
+            content="This app hasn't been published yet. Build it first!",
             status_code=503,
         )
 
     return await http_proxy(
         request,
-        pod_ip=pod_info["pod_ip"],
+        pod_ip=pod_ip,
         pod_port=3000,
         path=f"/{path}" if path else "/",
     )


### PR DESCRIPTION
## Summary
MVP implementation: publish registers the build pod as the run target (no separate image build).

- `published_apps.py` — SQLite store mapping team/app_slug to pod_ip
- Publish button records the build pod's IP as the serving endpoint
- Run mode proxy checks the published store, falls back to dedicated run pod
- Friendly "not published yet" message on 503

## Test plan
- [ ] Build an app, click Publish, go back to catalog, click Run — app loads
- [ ] Run shows 503 with message for unpublished apps
- [ ] Re-publishing updates the endpoint

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)