### PR TITLE
Improve Claude context, preview verification, and Publish UX

### DIFF
--- a/build-pod/CLAUDE.md
+++ b/build-pod/CLAUDE.md
@@ -41,6 +41,14 @@ Your users are **non-technical people** — marketing managers, finance analysts
 - They ask for changes, you make them.
 - When they're happy, they click **Save** or **Publish** (buttons at the top of the page).
 
+### Save and Publish
+
+When the user wants to save or publish:
+- Tell them: *"Click the **Save** button at the top right to save your progress."*
+- Tell them: *"Click the **Publish** button at the top right to make your app available to others."*
+- **Do NOT run git commands, gh commands, or try to create PRs yourself.** The platform handles all of that when the user clicks the buttons. You will see errors if you try (no git remote, no `gh` CLI).
+- If the user says "publish", "share", "go live", or "make it available" — always direct them to the **Publish** button.
+
 ---
 
 ## App Context
@@ -89,19 +97,30 @@ A background runner process watches `/repo` every 5 seconds and automatically st
 
 If the stack changes, the runner kills the old server and starts the correct one. If the server crashes, the runner restarts it automatically.
 
+### Verifying your work
+
+After creating or modifying files, **always verify the app is working** by running:
+```
+curl -s http://localhost:3000/
+```
+Do this silently — don't ask the user for permission. Check that:
+- The response is HTTP 200 (not an error page)
+- The content matches what the user asked for
+- If the server hasn't started yet, wait 10 seconds and try again
+
+If something is wrong, fix it immediately and tell the user: *"I noticed a small issue and fixed it — the preview should update now."*
+
+Do NOT tell the user to check anything themselves. YOU are the quality check.
+
 ---
 
 ## Git Workflow
 
-You manage all git operations **silently**. The user never touches git directly. Never mention git to the user.
+Git operations happen automatically in the background. **Never mention git to the user. Never run `git push`, `git remote`, `gh`, or any git commands manually.** The platform handles everything.
 
-| Event | Git action |
-|---|---|
-| New app session | `git checkout -b {user_id}/{app-slug}/{date}` |
-| Resume session | `git checkout {existing_branch}` |
-| Every 5 minutes | Auto-commit: `chore: autosave` |
-| User clicks **Save** | Named commit with a summary of changes |
-| User clicks **Publish** | Open a PR, run auditor, auto-merge to main |
+- Auto-commits happen every 5 minutes (silent background process).
+- The **Save** and **Publish** buttons in the UI handle saving and publishing.
+- There is no git remote configured — do not try to push or create PRs.
 
 ---
 

--- a/landing/app/templates/build.html
+++ b/landing/app/templates/build.html
@@ -331,15 +331,33 @@
     async function doPublish() {
       const btn = document.getElementById('btn-publish');
       btn.disabled = true;
+      btn.textContent = 'Publishing...';
       try {
         const resp = await fetch(`${BASE}/publish?pod_ip=${encodeURIComponent(POD_IP)}`, { method: 'POST' });
         const data = await resp.json();
         if (data.status === 'publish_requested') {
           btn.textContent = 'Published!';
-          setTimeout(() => { btn.textContent = 'Publish'; }, 2000);
+          btn.style.background = '#16a34a';
+          // Show success toast
+          const toast = document.createElement('div');
+          toast.style.cssText = 'position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:#16a34a;color:#fff;padding:12px 24px;border-radius:8px;font-size:14px;font-weight:600;z-index:9999;box-shadow:0 4px 12px rgba(0,0,0,0.3);';
+          toast.innerHTML = `Published! <a href="/run/${TEAM}/${APP_SLUG}" style="color:#fff;text-decoration:underline;margin-left:8px;">Run it now &rarr;</a>`;
+          document.body.appendChild(toast);
+          setTimeout(() => {
+            btn.textContent = 'Publish';
+            btn.style.background = '';
+            toast.remove();
+          }, 8000);
+        } else if (data.status === 'error') {
+          btn.textContent = 'Error';
+          btn.style.background = '#dc2626';
+          setTimeout(() => { btn.textContent = 'Publish'; btn.style.background = ''; }, 3000);
         }
       } catch (err) {
         console.error('Publish failed:', err);
+        btn.textContent = 'Error';
+        btn.style.background = '#dc2626';
+        setTimeout(() => { btn.textContent = 'Publish'; btn.style.background = ''; }, 3000);
       } finally {
         btn.disabled = false;
       }


### PR DESCRIPTION
## Summary
- **#55**: Claude now directs users to Save/Publish buttons instead of trying git/gh commands
- **#52**: Claude proactively verifies preview by curling localhost:3000 after changes
- **#56**: Publish button shows "Publishing..." → green "Published!" with "Run it now" link → or red "Error"

Closes #52, closes #55, closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)