### PR TITLE
Wire up monorepo as source of truth for catalog and publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CLUSTER_REGISTRY := sus-registry:5050
 LANDING_IMAGE := $(REGISTRY)/sus-landing
 BUILD_POD_IMAGE := $(REGISTRY)/sus-build
 TAG := dev
+GIT_REPO_URL ?= https://github.com/dev-dull/single-use-software.git
 
 .PHONY: help cluster-up cluster-down build push build-pod push-pod deploy upgrade dev teardown status logs
 
@@ -42,12 +43,14 @@ push-pod: ## Push the build pod image to the local registry
 deploy: ## Install the Helm chart into the cluster
 	helm install sus ./charts/sus \
 		--set landing.image.repository=$(CLUSTER_REGISTRY)/sus-landing \
-		--set landing.image.tag=$(TAG)
+		--set landing.image.tag=$(TAG) \
+		--set gitRepo.url=$(GIT_REPO_URL)
 
 upgrade: ## Upgrade the Helm release with latest values
 	helm upgrade sus ./charts/sus \
 		--set landing.image.repository=$(CLUSTER_REGISTRY)/sus-landing \
-		--set landing.image.tag=$(TAG)
+		--set landing.image.tag=$(TAG) \
+		--set gitRepo.url=$(GIT_REPO_URL)
 
 # --- Compound targets ---
 

--- a/build-pod/CLAUDE.md
+++ b/build-pod/CLAUDE.md
@@ -143,4 +143,9 @@ Skills are read-only reference material — do not modify them.
 
 ## Working Directory
 
-All work happens under `/repo`.
+You are working inside a monorepo. Your current directory is the app's directory:
+`/repo/apps/{team}/{app-slug}/`
+
+This directory contains the app's files: `sus.json`, `main.py`, `requirements.txt`, `index.html`, etc. All your file operations happen here. You do NOT need to create subdirectories under `apps/` — you're already in the right place.
+
+The full monorepo is at `/repo` but you should only modify files in your app directory.

--- a/build-pod/entrypoint.sh
+++ b/build-pod/entrypoint.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 #   GIT_USER_EMAIL  — git commit author email
 #   GIT_REPO_URL    — repository clone URL (SSH or HTTPS)
 #   GIT_BRANCH      — branch to check out (empty = default branch)
+#   APP_TEAM        — the team this app belongs to
+#   APP_SLUG        — the app's short name
 #   ANTHROPIC_API_KEY — API key for Claude Code
 # ---------------------------------------------------------------------------
 
@@ -16,16 +18,14 @@ set -euo pipefail
 
 git config --global user.name  "${GIT_USER_NAME:-sus-user}"
 git config --global user.email "${GIT_USER_EMAIL:-sus@localhost}"
-
-# Trust the /repo directory
 git config --global --add safe.directory /repo
 
-# --- Clone or checkout ----------------------------------------------------
+# --- Clone or init --------------------------------------------------------
 
 cd /repo
 
-if [ -n "${GIT_REPO_URL:-}" ] && [ "${GIT_REPO_URL}" != "https://github.com/sus/"* ]; then
-    # A real repo URL was provided — clone if not already cloned.
+if [ -n "${GIT_REPO_URL:-}" ]; then
+    # Clone the monorepo if not already cloned.
     if [ ! -d "/repo/.git" ]; then
         git clone "${GIT_REPO_URL}" /tmp/repo-clone
         cp -a /tmp/repo-clone/. /repo/
@@ -37,7 +37,7 @@ if [ -n "${GIT_REPO_URL:-}" ] && [ "${GIT_REPO_URL}" != "https://github.com/sus/
         git checkout "${GIT_BRANCH}" 2>/dev/null || git checkout -b "${GIT_BRANCH}"
     fi
 else
-    # No valid repo URL — initialize a local git repo for autosave.
+    # No repo URL — initialize a local git repo.
     if [ ! -d "/repo/.git" ]; then
         git init
         git add -A
@@ -49,14 +49,36 @@ else
     fi
 fi
 
+# --- Set up app working directory -----------------------------------------
+# Claude works inside apps/{team}/{app-slug}/ per the monorepo layout.
+
+APP_DIR="/repo/apps/${APP_TEAM:-_new}/${APP_SLUG:-_new}"
+mkdir -p "$APP_DIR"
+
+# If this is a new app, create a minimal sus.json.
+if [ ! -f "$APP_DIR/sus.json" ]; then
+    cat > "$APP_DIR/sus.json" <<SUSJSON
+{
+  "name": "${APP_NAME:-New App}",
+  "description": "${APP_DESCRIPTION:-}",
+  "owner": "${USER_ID:-anonymous}",
+  "team": "${APP_TEAM:-_new}",
+  "created_at": "$(date -u +%Y-%m-%d)",
+  "visibility": ["default"],
+  "default_stack": "python+htmx",
+  "tags": []
+}
+SUSJSON
+    git add -A 2>/dev/null || true
+    git commit -m "chore: scaffold ${APP_TEAM:-_new}/${APP_SLUG:-_new}" 2>/dev/null || true
+fi
+
 # --- Auto-commit loop -----------------------------------------------------
-# Runs in the background every 5 minutes.  If there are uncommitted changes
-# it creates a lightweight "autosave" commit so work is never lost.
 
 _autosave_loop() {
     while true; do
-        sleep 300  # 5 minutes
-        # Only commit if there are tracked or untracked changes
+        sleep 300
+        cd /repo
         if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
             git add -A
             git commit -m "chore: autosave" --no-verify 2>/dev/null || true
@@ -67,8 +89,7 @@ _autosave_loop() {
 _autosave_loop &
 
 # --- Runner: auto-start app on port 3000 ---------------------------------
-# Background watcher that detects servable content in /repo and starts the
-# appropriate server process.  Checks every 5 seconds.
+# Watches the app directory for servable content.
 
 SERVER_PID=""
 SERVER_TYPE=""
@@ -84,30 +105,25 @@ _kill_server() {
 
 _start_server() {
     local new_type="$1"
-
-    # If the stack changed, kill the old server first
     if [ -n "$SERVER_TYPE" ] && [ "$SERVER_TYPE" != "$new_type" ]; then
         _kill_server
     fi
-
-    # Already running with the right type — nothing to do
     if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
         return
     fi
 
     SERVER_TYPE="$new_type"
+    cd "$APP_DIR"
 
     case "$new_type" in
         python)
-            cd /repo
             pip install --user -q -r requirements.txt 2>/dev/null || true
             python3 -m uvicorn main:app --host 0.0.0.0 --port 3000 --reload &
             SERVER_PID=$!
             ;;
         node)
-            cd /repo
             npm install --silent 2>/dev/null || true
-            if grep -q '"start"' /repo/package.json 2>/dev/null; then
+            if grep -q '"start"' package.json 2>/dev/null; then
                 npm start &
             else
                 node server.js &
@@ -115,7 +131,6 @@ _start_server() {
             SERVER_PID=$!
             ;;
         static)
-            cd /repo
             python3 -m http.server 3000 &
             SERVER_PID=$!
             ;;
@@ -125,38 +140,28 @@ _start_server() {
 _runner_loop() {
     while true; do
         sleep 5
-
-        # Determine what kind of project exists in /repo
         detected=""
-        if [ -f /repo/requirements.txt ]; then
-            if grep -qiE 'fastapi|uvicorn' /repo/requirements.txt 2>/dev/null; then
+        if [ -f "$APP_DIR/requirements.txt" ]; then
+            if grep -qiE 'fastapi|uvicorn' "$APP_DIR/requirements.txt" 2>/dev/null; then
                 detected="python"
             fi
         fi
-
-        if [ -z "$detected" ] && [ -f /repo/package.json ]; then
+        if [ -z "$detected" ] && [ -f "$APP_DIR/package.json" ]; then
             detected="node"
         fi
-
-        if [ -z "$detected" ] && [ -f /repo/index.html ]; then
+        if [ -z "$detected" ] && [ -f "$APP_DIR/index.html" ]; then
             detected="static"
         fi
-
         if [ -z "$detected" ]; then
             continue
         fi
-
-        # If stack changed, kill old server
         if [ -n "$SERVER_TYPE" ] && [ "$SERVER_TYPE" != "$detected" ]; then
             _kill_server
         fi
-
-        # Restart if the server died
         if [ -n "$SERVER_PID" ] && ! kill -0 "$SERVER_PID" 2>/dev/null; then
             SERVER_PID=""
             SERVER_TYPE=""
         fi
-
         _start_server "$detected"
     done
 }
@@ -164,15 +169,11 @@ _runner_loop() {
 _runner_loop &
 
 # --- Start Claude Code CLI via ttyd ---------------------------------------
-# ttyd exposes the Claude Code CLI as a WebSocket terminal on port 8080.
-# The landing page proxies the browser's xterm.js to this WebSocket.
-#
-# Flags:
-#   --dangerously-skip-permissions  — pre-approved sandbox, no permission prompts
-#   --model sonnet                  — pre-select model to skip model-selection banner
-#   DISABLE_AUTOUPDATER=1           — suppress update notices (set in Dockerfile + below)
 
 export DISABLE_AUTOUPDATER=1
+
+# Start Claude in the app directory so it sees the app files.
+cd "$APP_DIR"
 
 exec ttyd --port 8080 --writable --base-path / \
     claude --dangerously-skip-permissions --model sonnet

--- a/charts/sus/templates/deployment.yaml
+++ b/charts/sus/templates/deployment.yaml
@@ -32,6 +32,16 @@ spec:
               value: {{ .Values.namespaces.workloads | quote }}
             - name: SUS_BUILD_IMAGE
               value: "{{ .Values.buildPod.image.repository }}:{{ .Values.buildPod.image.tag }}"
+            - name: SUS_GIT_REPO_URL
+              value: {{ .Values.gitRepo.url | quote }}
+            - name: SUS_REPO_CLONE_DIR
+              value: /data/repo
+          volumeMounts:
+            - name: repo-data
+              mountPath: /data
+      volumes:
+        - name: repo-data
+          emptyDir: {}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/sus/values.yaml
+++ b/charts/sus/values.yaml
@@ -46,6 +46,11 @@ buildPod:
       cpu: "2"
       memory: 2Gi
 
+# -- Git repository for the app monorepo
+gitRepo:
+  # -- URL of the monorepo (HTTPS or SSH)
+  url: ""
+
 # -- RBAC role name for pod management in the workloads namespace
 rbac:
   roleName: sus-pod-manager

--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY landing/requirements.txt .

--- a/landing/app/catalog.py
+++ b/landing/app/catalog.py
@@ -41,7 +41,8 @@ def scan_apps(
     """
 
     if root is None:
-        root = os.environ.get("SUS_APPS_ROOT", "/repo/apps")
+        from .repo_sync import get_apps_root
+        root = os.environ.get("SUS_APPS_ROOT", str(get_apps_root()))
 
     root = Path(root)
     apps: list[dict[str, Any]] = []

--- a/landing/app/main.py
+++ b/landing/app/main.py
@@ -66,8 +66,13 @@ app.add_middleware(NoCacheMiddleware)
 
 
 @app.on_event("startup")
-async def _start_cleanup_task() -> None:
-    """Launch the background cleanup loop when the app starts."""
+async def _start_background_tasks() -> None:
+    """Launch background tasks when the app starts."""
+    # Repo sync — clone/pull the monorepo for the catalog.
+    from .repo_sync import start_sync_loop
+    asyncio.create_task(start_sync_loop())
+
+    # Idle pod cleanup.
     pod_manager = BuildPodManager()
     session_store = SessionStore()
     asyncio.create_task(

--- a/landing/app/repo_sync.py
+++ b/landing/app/repo_sync.py
@@ -1,0 +1,78 @@
+"""Sync the monorepo to a local clone for catalog and run-mode serving."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CLONE_DIR = Path(os.environ.get("SUS_REPO_CLONE_DIR", "/data/repo"))
+REPO_URL = os.environ.get("SUS_GIT_REPO_URL", "")
+APPS_DIR = CLONE_DIR / "apps"
+
+
+def _run_git(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Run a git command and return the result."""
+    cmd = ["git"] + list(args)
+    return subprocess.run(
+        cmd,
+        cwd=cwd or CLONE_DIR,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def clone_or_pull() -> bool:
+    """Clone the monorepo (first time) or pull latest changes.
+
+    Returns True if successful, False otherwise.
+    """
+    if not REPO_URL:
+        logger.warning("SUS_GIT_REPO_URL not set — catalog will be empty")
+        return False
+
+    if (CLONE_DIR / ".git").is_dir():
+        # Already cloned — pull latest.
+        result = _run_git("pull", "--ff-only", cwd=CLONE_DIR)
+        if result.returncode == 0:
+            logger.info("Pulled latest from %s", REPO_URL)
+            return True
+        else:
+            logger.warning("Git pull failed: %s", result.stderr.strip())
+            # Try a reset to recover from diverged state.
+            _run_git("fetch", "origin", cwd=CLONE_DIR)
+            _run_git("reset", "--hard", "origin/main", cwd=CLONE_DIR)
+            return True
+    else:
+        # First clone.
+        CLONE_DIR.mkdir(parents=True, exist_ok=True)
+        result = _run_git("clone", REPO_URL, str(CLONE_DIR))
+        if result.returncode == 0:
+            logger.info("Cloned %s to %s", REPO_URL, CLONE_DIR)
+            return True
+        else:
+            logger.error("Git clone failed: %s", result.stderr.strip())
+            return False
+
+
+def get_apps_root() -> Path:
+    """Return the path to the apps/ directory in the local clone."""
+    return APPS_DIR
+
+
+async def start_sync_loop(interval_seconds: int = 30) -> None:
+    """Periodically pull the monorepo to pick up new/updated apps."""
+    # Initial clone.
+    clone_or_pull()
+
+    while True:
+        await asyncio.sleep(interval_seconds)
+        try:
+            clone_or_pull()
+        except Exception:
+            logger.exception("Repo sync failed")

--- a/landing/app/routes/run.py
+++ b/landing/app/routes/run.py
@@ -116,6 +116,16 @@ async def run_proxy(
         except Exception:
             logger.exception("Failed to find build pod for %s/%s", team, app_slug)
 
+    # 4. Fall back to serving static files from the repo clone.
+    if not pod_ip:
+        from ..repo_sync import get_apps_root
+        app_dir = get_apps_root() / team / app_slug
+        serve_path = path.strip("/") if path.strip("/") else "index.html"
+        static_file = app_dir / serve_path
+        if static_file.is_file():
+            from fastapi.responses import FileResponse
+            return FileResponse(static_file)
+
     if not pod_ip:
         return Response(
             content="This app hasn't been published yet. Build it first!",


### PR DESCRIPTION
## Summary
The monorepo is now the single source of truth for apps. The landing page
clones the repo on startup, reads the catalog from apps/, and pulls every
30s. Build pods clone the repo and work inside apps/{team}/{app-slug}/.
Demo apps ship naturally as part of the repo.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)