### PR TITLE
ci: Claude automated PR review on every PR

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -9,7 +9,9 @@ name: Claude PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # ready_for_review covers draft -> ready with no further push (the draft
+    # guard below would otherwise leave it unreviewed until the next commit).
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # One review per PR. cancel-in-progress is false so a superseded run isn't
 # killed mid-write, which would freeze its progress-tracking comment.
@@ -34,6 +36,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      # Pin helm via the same action publish-chart.yaml uses, so the version
+      # that reviews the chart matches the one that ships it (avoids drift from
+      # relying on whatever helm the runner image happens to bundle).
+      - uses: azure/setup-helm@v4
 
       - uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -66,7 +66,10 @@ jobs:
               params), secret handling, and shell injection in build-pod/*.sh.
             - Helm chart correctness (charts/sus/): when the chart changed, render
               it with `helm template` (both auth on and off) and check values
-              wiring and that auth-off output is unchanged.
+              wiring. For auth-off, confirm the render contains no Authelia/auth
+              resources so the feature stays opt-in. (Comparing against the base
+              branch isn't available here — reason from the head render plus the
+              PR diff.)
             - Test coverage gaps for the above.
 
             Prioritize a small number of high-confidence, actionable findings over

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -3,28 +3,33 @@ name: Claude PR Review
 # Automatically reviews every pull request when it's opened or updated.
 # Requires a repository secret named ANTHROPIC_API_KEY
 #   (Settings → Secrets and variables → Actions → New repository secret).
-# Note: this does not run on PRs from forks — GitHub withholds secrets from
-# fork workflows, so only PRs from branches in this repo are reviewed.
+# Uses the built-in GITHUB_TOKEN, so no Claude GitHub App install is needed.
+# Fork PRs are skipped (they have no secret + a read-only token) rather than
+# failed — see the head-repo guard below.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# One review per PR ref; cancel a superseded run when new commits land.
+# One review per PR. cancel-in-progress is false so a superseded run isn't
+# killed mid-write, which would freeze its progress-tracking comment.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   review:
-    # Skip drafts — review once it's marked ready.
-    if: github.event.pull_request.draft == false
+    # Skip drafts, and skip fork PRs (their runs have no ANTHROPIC_API_KEY and a
+    # read-only token, so they'd fail rather than no-op).
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,8 +52,9 @@ jobs:
               trusted-proxy handling (landing/app/identity.py, deps.py, proxy.py),
               anything that reads client-supplied values (headers, pod_ip, query
               params), secret handling, and shell injection in build-pod/*.sh.
-            - Helm chart correctness (charts/sus/): template rendering, values
-              wiring, and that changes stay backward-compatible when auth is off.
+            - Helm chart correctness (charts/sus/): when the chart changed, render
+              it with `helm template` (both auth on and off) and check values
+              wiring and that auth-off output is unchanged.
             - Test coverage gaps for the above.
 
             Prioritize a small number of high-confidence, actionable findings over
@@ -57,6 +63,6 @@ jobs:
 
             Post specific issues as inline comments on the relevant lines using
             mcp__github_inline_comment__create_inline_comment (with confirmed: true),
-            and leave one short summary comment via `gh pr comment`.
+            and put a short overall summary in your tracked comment.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(helm template:*),Bash(helm lint:*)"

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -37,10 +37,15 @@ jobs:
         with:
           fetch-depth: 1
 
-      # Pin helm via the same action publish-chart.yaml uses, so the version
-      # that reviews the chart matches the one that ships it (avoids drift from
-      # relying on whatever helm the runner image happens to bundle).
+      # Install helm explicitly (same action publish-chart.yaml uses) and pin it.
+      # Two reasons to pin rather than let it default to `latest`: (1) the chart
+      # rendering here shouldn't shift under a future helm release, and (2) helm
+      # 4.x closes the `--post-renderer` arbitrary-executable path that in helm 3
+      # was a clean escape from the `Bash(helm template:*)` allowlist. Keep this
+      # version in sync with publish-chart.yaml.
       - uses: azure/setup-helm@v4
+        with:
+          version: v4.2.3
 
       - uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,58 @@
+name: Claude PR Review
+
+# Automatically reviews every pull request when it's opened or updated.
+# Requires a repository secret named ANTHROPIC_API_KEY
+#   (Settings → Secrets and variables → Actions → New repository secret).
+# Note: this does not run on PRs from forks — GitHub withholds secrets from
+# fork workflows, so only PRs from branches in this repo are reviewed.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# One review per PR ref; cancel a superseded run when new commits land.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Skip drafts — review once it's marked ready.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            Review this pull request. SUS is a self-hosted platform that runs
+            Claude Code in per-session Kubernetes pods, so weigh these areas:
+
+            - Correctness and likely bugs in the changed code.
+            - Security, especially the app→platform trust boundary: identity /
+              trusted-proxy handling (landing/app/identity.py, deps.py, proxy.py),
+              anything that reads client-supplied values (headers, pod_ip, query
+              params), secret handling, and shell injection in build-pod/*.sh.
+            - Helm chart correctness (charts/sus/): template rendering, values
+              wiring, and that changes stay backward-compatible when auth is off.
+            - Test coverage gaps for the above.
+
+            Prioritize a small number of high-confidence, actionable findings over
+            exhaustiveness. Match the repo's existing style; don't nitpick
+            formatting. If the PR looks good, say so briefly.
+
+            Post specific issues as inline comments on the relevant lines using
+            mcp__github_inline_comment__create_inline_comment (with confirmed: true),
+            and leave one short summary comment via `gh pr comment`.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,6 +33,10 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Use the workflow's built-in token instead of the Claude GitHub App,
+          # so no app install is needed. GITHUB_TOKEN inherits the permissions
+          # block above (pull-requests/issues: write) for posting comments.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           prompt: |
             Review this pull request. SUS is a self-hosted platform that runs

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -20,6 +20,10 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v4
+        with:
+          # Pinned; keep in sync with claude-review.yaml so the helm that
+          # reviews the chart is the same one that packages/publishes it.
+          version: v4.2.3
 
       - name: Set chart version from tag
         run: |


### PR DESCRIPTION
Adds `.github/workflows/claude-review.yml` — Claude reviews every PR automatically.

## What it does
- Triggers on `pull_request` (opened, synchronize, reopened); skips drafts.
- Runs `anthropics/claude-code-action@v1`, which reviews the diff and posts inline comments on specific lines plus one summary comment.
- Review prompt is tuned to this repo's risk areas: the app→platform trust boundary (identity / trusted-proxy / proxy handling, anything reading client-supplied values, secret handling), shell injection in `build-pod/*.sh`, and Helm chart template/values correctness (incl. auth-off backward-compatibility).
- One review per PR, `cancel-in-progress` on new pushes; least-privilege permissions (`contents: read`, PR/issue write for comments).

## ⚠️ Required before it works
The repo owner must add a repository secret **`ANTHROPIC_API_KEY`** (Settings → Secrets and variables → Actions → New repository secret). Without it, the action fails.

Alternatives if you prefer not to use a raw API key: a `CLAUDE_CODE_OAUTH_TOKEN` secret (swap the input to `claude_code_oauth_token`), or Bedrock/Vertex via the action's `use_bedrock`/`use_vertex` flags.

## Notes
- **Fork PRs won't be reviewed** — GitHub withholds secrets from fork workflows. Only PRs from branches in this repo trigger a review.
- Once the secret is added, this PR will self-review on its next push (Claude reviewing the workflow that adds Claude review).
- Model uses the account default; pin one by adding `--model <id>` to `claude_args` if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
