### PR TITLE
Default build-session model to Opus 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,13 @@ SUS can be configured two ways:
 | App repo URL | `/setup` | `--set gitRepo.url=...` |
 | Anthropic API key | `/setup` | K8s secret `sus-anthropic-api-key` |
 | Git access token | `/setup` | K8s secret `sus-git-token` |
-| Claude model for build sessions | — | `--set buildPod.claudeModel=sonnet` (aliases like `sonnet`/`opus`/`haiku` track the latest model; a full ID pins one) |
+| Claude model for build sessions | — | `--set buildPod.claudeModel=opus` (default; aliases like `opus`/`sonnet`/`haiku` track the latest model, a full ID pins one — see note below) |
 | Build pod resources | — | `buildPod.resources` in `values.yaml` |
 | Landing page resources | — | `landing.resources` in `values.yaml` |
 
 See [`charts/sus/values.yaml`](charts/sus/values.yaml) for all Helm values.
+
+**Build-session model:** the default is `opus` (Claude Opus 5) — Anthropic's recommended model for agentic coding, so the best build quality. It costs roughly **2.5× more per token** than `sonnet` and responds a bit slower. If you'd rather trade some build quality for lower cost and faster responses, set `--set buildPod.claudeModel=sonnet` (Claude Sonnet 5). Aliases track the latest model in each family; pass a full ID like `claude-opus-5` to pin a version.
 
 ### Ingress
 

--- a/build-pod/entrypoint.sh
+++ b/build-pod/entrypoint.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 #   APP_TEAM        — the team this app belongs to
 #   APP_SLUG        — the app's short name
 #   ANTHROPIC_API_KEY — API key for Claude Code
-#   CLAUDE_MODEL    — Claude model for the session (default: sonnet)
+#   CLAUDE_MODEL    — Claude model for the session (default: opus)
 # ---------------------------------------------------------------------------
 
 # --- Git configuration ----------------------------------------------------
@@ -258,4 +258,4 @@ with open(path, "w") as f:
 PYEOF
 
 exec ttyd --port 8080 --writable --base-path / \
-    bash -c "cd '$APP_DIR' && exec claude --dangerously-skip-permissions --model '${CLAUDE_MODEL:-sonnet}'"
+    bash -c "cd '$APP_DIR' && exec claude --dangerously-skip-permissions --model '${CLAUDE_MODEL:-opus}'"

--- a/charts/sus/templates/NOTES.txt
+++ b/charts/sus/templates/NOTES.txt
@@ -11,6 +11,12 @@ To access the landing page locally, run:
   kubectl port-forward -n {{ .Values.namespaces.platform }} svc/{{ include "sus.fullname" . }}-landing {{ .Values.service.port }}:{{ .Values.service.port }}
 
 Then open http://localhost:{{ .Values.service.port }} in your browser.
+
+Build sessions use the "{{ .Values.buildPod.claudeModel }}" Claude model.
+{{- if eq .Values.buildPod.claudeModel "opus" }}
+  This is Claude Opus 5 — best build quality, but ~2.5x the per-token cost of
+  "sonnet" and a bit slower. Set --set buildPod.claudeModel=sonnet to lower cost.
+{{- end }}
 {{- if .Values.auth.enabled }}
 
 Authentication (Authelia) is ENABLED. The chart deploys Authelia and switches the

--- a/charts/sus/values.yaml
+++ b/charts/sus/values.yaml
@@ -35,10 +35,14 @@ buildPod:
     repository: ghcr.io/dev-dull/sus-build
     tag: latest
     pullPolicy: Always
-  # -- Claude model for build sessions. Aliases like "sonnet", "opus", and
+  # -- Claude model for build sessions. Aliases like "opus", "sonnet", and
   # "haiku" resolve to the latest model in that family; a full model ID
-  # (e.g. "claude-sonnet-5") pins a specific version.
-  claudeModel: sonnet
+  # (e.g. "claude-opus-5") pins a specific version.
+  # Default "opus" (Claude Opus 5) — Anthropic's recommended model for agentic
+  # coding, i.e. the best build quality. It costs ~2.5x more per token than
+  # "sonnet" and is a bit slower; set claudeModel: sonnet to trade some build
+  # quality for lower cost and faster responses.
+  claudeModel: opus
   ports:
     terminal: 8080
     preview: 3000

--- a/landing/app/pods.py
+++ b/landing/app/pods.py
@@ -99,7 +99,7 @@ class BuildPodManager:
                             client.V1EnvVar(name="SUS_API_URL", value="http://sus-landing.sus.svc.cluster.local"),
                             client.V1EnvVar(
                                 name="CLAUDE_MODEL",
-                                value=os.environ.get("SUS_CLAUDE_MODEL", "sonnet"),
+                                value=os.environ.get("SUS_CLAUDE_MODEL", "opus"),
                             ),
                             client.V1EnvVar(
                                 name="ANTHROPIC_API_KEY",


### PR DESCRIPTION
Changes the default Claude model for build sessions from the `sonnet` alias to `opus` (Claude Opus 5, which just shipped).

## Why
Claude Opus 5 is Anthropic's recommended model for **agentic coding** — which is precisely what a SUS build session is. For non-technical users, higher build quality and first-shot success means less frustrating back-and-forth (which can also *reduce* total token spend).

## Tradeoff (documented)
Opus 5 costs **~2.5× more per token** than Sonnet 5 ($5/$25 vs $2/$10 introductory) and responds a bit slower. Operators who prefer lower cost / faster responses can set `--set buildPod.claudeModel=sonnet`. This is called out in both `values.yaml` and the README.

## What changed
Updated the default in every place it's resolved so "the default is Opus" holds regardless of entry point:
- `charts/sus/values.yaml` → `buildPod.claudeModel: opus` (+ comment explaining the tradeoff)
- `landing/app/pods.py` → `SUS_CLAUDE_MODEL` env fallback
- `build-pod/entrypoint.sh` → `CLAUDE_MODEL` fallback + doc comment
- `README.md` → config table row + a build-session-model note

Uses the `opus` **alias** (not the pinned `claude-opus-5`) so it auto-tracks future Opus releases, matching the existing `sonnet`/`haiku` convention. A full ID like `claude-opus-5` can be set to pin a version.

## Verification
`helm template` renders `SUS_CLAUDE_MODEL="opus"`; `helm lint` clean; `pods.py` compiles. Model IDs/pricing verified against Anthropic's live model + pricing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)