### PR TITLE
Seed initial build prompt for new apps (not existing-app sessions)

### DIFF
--- a/build-pod/CLAUDE.md
+++ b/build-pod/CLAUDE.md
@@ -61,7 +61,10 @@ Check these environment variables for context about what you're building:
 - `APP_NAME` — the human-readable app name (if set)
 - `APP_DESCRIPTION` — what the app should do (if set)
 
-If `APP_DESCRIPTION` is set, use it as your starting context. The user expects the app to match this description. If the current state of the app doesn't match, proactively offer to fix it.
+If `APP_DESCRIPTION` is set, treat it as helpful background about what the app was originally meant to do.
+
+- **Brand-new app:** you'll receive an initial instruction to build it — follow that and get a working first version into the preview right away.
+- **Existing app you're resuming:** the description may be the *original* spec, and the app may have intentionally moved on from it. Don't assume any difference is a mistake, and don't start changing things unprompted. Wait for the user to tell you what they want; only offer to align the app with the description if it seems genuinely relevant.
 
 ---
 

--- a/build-pod/entrypoint.sh
+++ b/build-pod/entrypoint.sh
@@ -77,18 +77,25 @@ mkdir -p "$APP_DIR"
 NEW_APP=0
 if [ ! -f "$APP_DIR/sus.json" ]; then
     NEW_APP=1
-    cat > "$APP_DIR/sus.json" <<SUSJSON
-{
-  "name": "${APP_NAME:-New App}",
-  "description": "${APP_DESCRIPTION:-}",
-  "owner": "${USER_ID:-anonymous}",
-  "team": "${APP_TEAM:-_new}",
-  "created_at": "$(date -u +%Y-%m-%d)",
-  "visibility": ["default"],
-  "default_stack": "python+htmx",
-  "tags": []
+    # Build the manifest with json.dump, not a heredoc: APP_NAME and especially
+    # APP_DESCRIPTION are free-form user input (a <textarea>), so a quote or
+    # newline spliced into hand-written JSON yields an invalid sus.json — and
+    # catalog.py silently drops apps whose manifest won't parse.
+    APP_DIR="$APP_DIR" python3 - <<'PYEOF'
+import datetime, json, os
+data = {
+    "name": os.environ.get("APP_NAME") or "New App",
+    "description": os.environ.get("APP_DESCRIPTION", ""),
+    "owner": os.environ.get("USER_ID") or "anonymous",
+    "team": os.environ.get("APP_TEAM") or "_new",
+    "created_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
+    "visibility": ["default"],
+    "default_stack": "python+htmx",
+    "tags": [],
 }
-SUSJSON
+with open(os.path.join(os.environ["APP_DIR"], "sus.json"), "w") as f:
+    json.dump(data, f, indent=2)
+PYEOF
     git add -A 2>/dev/null || true
     git commit -m "chore: scaffold ${APP_TEAM:-_new}/${APP_SLUG:-_new}" 2>/dev/null || true
 fi
@@ -262,26 +269,50 @@ with open(path, "w") as f:
     json.dump(data, f)
 PYEOF
 
-# For a brand-new app with a description, seed an initial prompt so Claude
+# For a brand-new app with a description, hand Claude an initial prompt so it
 # starts building to spec on the first turn — otherwise the form description
-# only reaches the session as an env var the CLAUDE.md *asks* Claude to read,
-# which isn't guaranteed. Gated to NEW_APP: an existing-app "Build" session
-# must NOT be auto-kicked — its sus.json description may be stale and the user
-# is about to say what they want.
+# only reaches the session as an env var CLAUDE.md *asks* Claude to read, which
+# isn't guaranteed. Gated to NEW_APP: an existing-app "Build" session must NOT
+# be auto-kicked — its sus.json description may be stale and the user is about
+# to say what they want.
 #
-# The description is untrusted user input, so it is passed via an exported env
-# var and expanded by the INNER shell as a single quoted argument (note the
-# escaped \$SUS_INITIAL_PROMPT). It is never spliced into the command string,
-# so it cannot break quoting or inject shell.
+# One-shot, and this matters: ttyd spawns a fresh `claude` per *client
+# connection*, and the frontend reconnects on its own (terminal-iframe reload on
+# a not-ready blip, a full page reload after ~15s, a manual refresh, a second
+# tab). If every connection were seeded, a reconnect hours into a session would
+# re-run "build the initial version" over the user's work — and autosave would
+# commit the clobber. So we drop the prompt in a seed file and let the inner
+# shell claim it with an atomic `mv` that succeeds exactly once: only the first
+# connection is seeded; every later one falls through to a plain interactive
+# session. (NEW_APP alone can't gate this — it's fixed for the pod's lifetime.)
+#
+# APP_DESCRIPTION is untrusted: it's expanded into the seed file by the heredoc
+# (bash does not re-scan an expansion's contents) and reaches claude as a single
+# "$(cat …)" word — never spliced into the command string, so it cannot break
+# quoting or inject shell.
 if [ "${NEW_APP:-0}" = "1" ] && [ -n "${APP_DESCRIPTION:-}" ]; then
-    export SUS_INITIAL_PROMPT="Build this app now and show it in the preview pane on the right. Here is what it should do:
+    SUS_SEED_FILE=/tmp/sus-initial-prompt
+    cat > "$SUS_SEED_FILE" <<SEEDEOF
+Build this app now and show it in the preview pane on the right. Here is what it should do:
 
 ${APP_DESCRIPTION}
 
-Create the initial working version straight away, then tell me it's ready."
-    exec ttyd --port 8080 --writable --base-path / \
-        bash -c "cd '$APP_DIR' && exec claude --dangerously-skip-permissions --model '${CLAUDE_MODEL:-opus}' \"\$SUS_INITIAL_PROMPT\""
-else
-    exec ttyd --port 8080 --writable --base-path / \
-        bash -c "cd '$APP_DIR' && exec claude --dangerously-skip-permissions --model '${CLAUDE_MODEL:-opus}'"
+Create the initial working version straight away, then tell me it's ready.
+SEEDEOF
+    export SUS_SEED_FILE
 fi
+
+export APP_DIR
+export CLAUDE_MODEL="${CLAUDE_MODEL:-opus}"
+# Single-quoted on purpose: $APP_DIR/$SUS_SEED_FILE/$CLAUDE_MODEL and the
+# $(cat …) must be evaluated by the inner per-connection shell (so the mv/cat
+# run once per connection), not baked in once by this shell at exec time.
+# shellcheck disable=SC2016
+exec ttyd --port 8080 --writable --base-path / \
+    bash -c '
+        cd "$APP_DIR" || exit 1
+        if [ -n "${SUS_SEED_FILE:-}" ] && mv "$SUS_SEED_FILE" "$SUS_SEED_FILE.used" 2>/dev/null; then
+            exec claude --dangerously-skip-permissions --model "$CLAUDE_MODEL" "$(cat "$SUS_SEED_FILE.used")"
+        fi
+        exec claude --dangerously-skip-permissions --model "$CLAUDE_MODEL"
+    '

--- a/build-pod/entrypoint.sh
+++ b/build-pod/entrypoint.sh
@@ -70,8 +70,13 @@ fi
 APP_DIR="/repo/${APP_TEAM:-_new}/${APP_SLUG:-_new}"
 mkdir -p "$APP_DIR"
 
-# If this is a new app, create a minimal sus.json.
+# If this is a new app, create a minimal sus.json. The absence of sus.json is
+# also our "brand-new app" signal (an existing app's clone brings its own down),
+# and it's restart-safe: a recreated pod re-clones the now-committed scaffold, so
+# NEW_APP reads 0 and we don't re-kick a build on restart.
+NEW_APP=0
 if [ ! -f "$APP_DIR/sus.json" ]; then
+    NEW_APP=1
     cat > "$APP_DIR/sus.json" <<SUSJSON
 {
   "name": "${APP_NAME:-New App}",
@@ -257,5 +262,26 @@ with open(path, "w") as f:
     json.dump(data, f)
 PYEOF
 
-exec ttyd --port 8080 --writable --base-path / \
-    bash -c "cd '$APP_DIR' && exec claude --dangerously-skip-permissions --model '${CLAUDE_MODEL:-opus}'"
+# For a brand-new app with a description, seed an initial prompt so Claude
+# starts building to spec on the first turn — otherwise the form description
+# only reaches the session as an env var the CLAUDE.md *asks* Claude to read,
+# which isn't guaranteed. Gated to NEW_APP: an existing-app "Build" session
+# must NOT be auto-kicked — its sus.json description may be stale and the user
+# is about to say what they want.
+#
+# The description is untrusted user input, so it is passed via an exported env
+# var and expanded by the INNER shell as a single quoted argument (note the
+# escaped \$SUS_INITIAL_PROMPT). It is never spliced into the command string,
+# so it cannot break quoting or inject shell.
+if [ "${NEW_APP:-0}" = "1" ] && [ -n "${APP_DESCRIPTION:-}" ]; then
+    export SUS_INITIAL_PROMPT="Build this app now and show it in the preview pane on the right. Here is what it should do:
+
+${APP_DESCRIPTION}
+
+Create the initial working version straight away, then tell me it's ready."
+    exec ttyd --port 8080 --writable --base-path / \
+        bash -c "cd '$APP_DIR' && exec claude --dangerously-skip-permissions --model '${CLAUDE_MODEL:-opus}' \"\$SUS_INITIAL_PROMPT\""
+else
+    exec ttyd --port 8080 --writable --base-path / \
+        bash -c "cd '$APP_DIR' && exec claude --dangerously-skip-permissions --model '${CLAUDE_MODEL:-opus}'"
+fi

--- a/build-pod/entrypoint.sh
+++ b/build-pod/entrypoint.sh
@@ -305,37 +305,27 @@ fi
 
 export APP_DIR
 export CLAUDE_MODEL="${CLAUDE_MODEL:-opus}"
-# Single-quoted on purpose: $APP_DIR/$SUS_SEED_FILE/$CLAUDE_MODEL and the
-# $(cat …) must be evaluated by the inner per-connection shell (so the mv/cat
-# run once per connection), not baked in once by this shell at exec time.
+# ttyd spawns a fresh `claude` per client connection, so consume the seed with
+# an atomic `mv` that succeeds exactly once: the first connection is seeded,
+# every later one (reconnect, refresh, second tab) falls through to a plain
+# interactive session and never re-runs the build over the user's work.
+#
+# Deliberately NOT recovered: if an early reconnect kills the very first build
+# before it writes a file, the replacement session is plain and the user just
+# restates the request. Auto-recovering that (re-arming the seed) needs a
+# claimant-liveness protocol whose races aren't worth it for a first-turn
+# convenience — a plain session is a fine, non-destructive fallback.
+#
+# Single-quoted body on purpose: $APP_DIR/$SUS_SEED_FILE/$CLAUDE_MODEL and the
+# $(cat …) are evaluated by the inner per-connection shell, not baked in once
+# by this shell at exec time. The untrusted description lives only in the seed
+# file and reaches claude as a single "$(cat …)" argv word — never spliced into
+# the command string, so it can't break quoting or inject shell.
 # shellcheck disable=SC2016
 exec ttyd --port 8080 --writable --base-path / \
     bash -c '
         cd "$APP_DIR" || exit 1
-        # Re-arm a seed consumed by a session that died before Claude wrote
-        # anything (e.g. an early frontend reconnect SIGHUPs the still-building
-        # claude), so the replacement connection still gets kicked. Re-arm only
-        # when ALL hold, or we risk launching a *second concurrent*
-        # --dangerously-skip-permissions build over the same dir:
-        #   - a claim happened ($SUS_SEED_FILE.used exists),
-        #   - the claimant recorded its pid AND that pid is now dead — kill -0
-        #     (a bash builtin; procps/pgrep are not in the image). A *missing*
-        #     .pid means a claim is mid-flight (the mv below and the pid write
-        #     are not atomic), i.e. a live claimant, so we must NOT treat its
-        #     absence as death, and
-        #   - the app dir still holds nothing but sus.json (no user work).
-        # Once Claude writes any file the re-arm stops firing and the seed is
-        # one-shot for the rest of the session.
-        if [ -n "${SUS_SEED_FILE:-}" ] && [ -f "$SUS_SEED_FILE.used" ] \
-           && [ -f "$SUS_SEED_FILE.pid" ] \
-           && ! kill -0 "$(cat "$SUS_SEED_FILE.pid" 2>/dev/null)" 2>/dev/null \
-           && [ -z "$(ls -A . 2>/dev/null | grep -v "^sus\.json$")" ]; then
-            mv "$SUS_SEED_FILE.used" "$SUS_SEED_FILE" 2>/dev/null || true
-        fi
         if [ -n "${SUS_SEED_FILE:-}" ] && mv "$SUS_SEED_FILE" "$SUS_SEED_FILE.used" 2>/dev/null; then
-            # $$ is this shell, which becomes claude via exec — so the pid file
-            # tracks the live build for the liveness check above.
-            echo "$$" > "$SUS_SEED_FILE.pid"
             exec claude --dangerously-skip-permissions --model "$CLAUDE_MODEL" "$(cat "$SUS_SEED_FILE.used")"
         fi
         exec claude --dangerously-skip-permissions --model "$CLAUDE_MODEL"

--- a/build-pod/entrypoint.sh
+++ b/build-pod/entrypoint.sh
@@ -95,6 +95,7 @@ data = {
 }
 with open(os.path.join(os.environ["APP_DIR"], "sus.json"), "w") as f:
     json.dump(data, f, indent=2)
+    f.write("\n")
 PYEOF
     git add -A 2>/dev/null || true
     git commit -m "chore: scaffold ${APP_TEAM:-_new}/${APP_SLUG:-_new}" 2>/dev/null || true
@@ -311,6 +312,16 @@ export CLAUDE_MODEL="${CLAUDE_MODEL:-opus}"
 exec ttyd --port 8080 --writable --base-path / \
     bash -c '
         cd "$APP_DIR" || exit 1
+        # Re-arm a seed consumed by a connection that died before Claude wrote
+        # anything — e.g. an early frontend reconnect (health-watch starts ~5s
+        # in) SIGHUPs the still-building session. Safe precisely because "nothing
+        # but sus.json in the app dir" means there is no user work to clobber;
+        # once Claude has written any file this stops firing and the one-shot
+        # guarantee holds for the rest of the session.
+        if [ -n "${SUS_SEED_FILE:-}" ] && [ -f "$SUS_SEED_FILE.used" ] \
+           && [ -z "$(ls -A . 2>/dev/null | grep -v "^sus\.json$")" ]; then
+            mv "$SUS_SEED_FILE.used" "$SUS_SEED_FILE" 2>/dev/null || true
+        fi
         if [ -n "${SUS_SEED_FILE:-}" ] && mv "$SUS_SEED_FILE" "$SUS_SEED_FILE.used" 2>/dev/null; then
             exec claude --dangerously-skip-permissions --model "$CLAUDE_MODEL" "$(cat "$SUS_SEED_FILE.used")"
         fi

--- a/build-pod/entrypoint.sh
+++ b/build-pod/entrypoint.sh
@@ -312,17 +312,27 @@ export CLAUDE_MODEL="${CLAUDE_MODEL:-opus}"
 exec ttyd --port 8080 --writable --base-path / \
     bash -c '
         cd "$APP_DIR" || exit 1
-        # Re-arm a seed consumed by a connection that died before Claude wrote
-        # anything — e.g. an early frontend reconnect (health-watch starts ~5s
-        # in) SIGHUPs the still-building session. Safe precisely because "nothing
-        # but sus.json in the app dir" means there is no user work to clobber;
-        # once Claude has written any file this stops firing and the one-shot
-        # guarantee holds for the rest of the session.
+        # Re-arm a seed consumed by a session that died before Claude wrote
+        # anything (e.g. an early frontend reconnect SIGHUPs the still-building
+        # claude), so the replacement connection still gets kicked. Two guards
+        # keep this from starting a *second concurrent* build:
+        #   - the app dir must still hold nothing but sus.json (no user work), and
+        #   - the previous claimant must be dead — kill -0 on the pid it recorded
+        #     (kill is a bash builtin; procps/pgrep are not in the image).
+        # Without the liveness check a second client (a new tab, or a reconnect
+        # that beats SIGHUP to the old claude) would re-arm while the first build
+        # is still running and launch another --dangerously-skip-permissions build
+        # over the same dir. Once Claude writes any file the re-arm stops firing
+        # and the seed is one-shot for the rest of the session.
         if [ -n "${SUS_SEED_FILE:-}" ] && [ -f "$SUS_SEED_FILE.used" ] \
-           && [ -z "$(ls -A . 2>/dev/null | grep -v "^sus\.json$")" ]; then
+           && [ -z "$(ls -A . 2>/dev/null | grep -v "^sus\.json$")" ] \
+           && ! { [ -f "$SUS_SEED_FILE.pid" ] && kill -0 "$(cat "$SUS_SEED_FILE.pid" 2>/dev/null)" 2>/dev/null; }; then
             mv "$SUS_SEED_FILE.used" "$SUS_SEED_FILE" 2>/dev/null || true
         fi
         if [ -n "${SUS_SEED_FILE:-}" ] && mv "$SUS_SEED_FILE" "$SUS_SEED_FILE.used" 2>/dev/null; then
+            # $$ is this shell, which becomes claude via exec — so the pid file
+            # tracks the live build for the liveness check above.
+            echo "$$" > "$SUS_SEED_FILE.pid"
             exec claude --dangerously-skip-permissions --model "$CLAUDE_MODEL" "$(cat "$SUS_SEED_FILE.used")"
         fi
         exec claude --dangerously-skip-permissions --model "$CLAUDE_MODEL"

--- a/build-pod/entrypoint.sh
+++ b/build-pod/entrypoint.sh
@@ -314,19 +314,22 @@ exec ttyd --port 8080 --writable --base-path / \
         cd "$APP_DIR" || exit 1
         # Re-arm a seed consumed by a session that died before Claude wrote
         # anything (e.g. an early frontend reconnect SIGHUPs the still-building
-        # claude), so the replacement connection still gets kicked. Two guards
-        # keep this from starting a *second concurrent* build:
-        #   - the app dir must still hold nothing but sus.json (no user work), and
-        #   - the previous claimant must be dead — kill -0 on the pid it recorded
-        #     (kill is a bash builtin; procps/pgrep are not in the image).
-        # Without the liveness check a second client (a new tab, or a reconnect
-        # that beats SIGHUP to the old claude) would re-arm while the first build
-        # is still running and launch another --dangerously-skip-permissions build
-        # over the same dir. Once Claude writes any file the re-arm stops firing
-        # and the seed is one-shot for the rest of the session.
+        # claude), so the replacement connection still gets kicked. Re-arm only
+        # when ALL hold, or we risk launching a *second concurrent*
+        # --dangerously-skip-permissions build over the same dir:
+        #   - a claim happened ($SUS_SEED_FILE.used exists),
+        #   - the claimant recorded its pid AND that pid is now dead — kill -0
+        #     (a bash builtin; procps/pgrep are not in the image). A *missing*
+        #     .pid means a claim is mid-flight (the mv below and the pid write
+        #     are not atomic), i.e. a live claimant, so we must NOT treat its
+        #     absence as death, and
+        #   - the app dir still holds nothing but sus.json (no user work).
+        # Once Claude writes any file the re-arm stops firing and the seed is
+        # one-shot for the rest of the session.
         if [ -n "${SUS_SEED_FILE:-}" ] && [ -f "$SUS_SEED_FILE.used" ] \
-           && [ -z "$(ls -A . 2>/dev/null | grep -v "^sus\.json$")" ] \
-           && ! { [ -f "$SUS_SEED_FILE.pid" ] && kill -0 "$(cat "$SUS_SEED_FILE.pid" 2>/dev/null)" 2>/dev/null; }; then
+           && [ -f "$SUS_SEED_FILE.pid" ] \
+           && ! kill -0 "$(cat "$SUS_SEED_FILE.pid" 2>/dev/null)" 2>/dev/null \
+           && [ -z "$(ls -A . 2>/dev/null | grep -v "^sus\.json$")" ]; then
             mv "$SUS_SEED_FILE.used" "$SUS_SEED_FILE" 2>/dev/null || true
         fi
         if [ -n "${SUS_SEED_FILE:-}" ] && mv "$SUS_SEED_FILE" "$SUS_SEED_FILE.used" 2>/dev/null; then


### PR DESCRIPTION
## Problem
When a user creates a **new app**, the form description reaches the build session only as the `APP_DESCRIPTION` environment variable. Nothing feeds it into Claude's actual conversation — the pod's `CLAUDE.md` merely *instructs* Claude to go read that env var. That's a soft nudge, not a guarantee: on turn one Claude's context holds the *instruction* but not the *value*, so a carefully-described app can sit idle until the user re-types what they wanted.

## Fix
Seed the description as Claude's **opening prompt** so a new app builds to spec immediately.

Critically, this is **gated to brand-new apps only**. An existing-app "Build" session is different:
- there's no form — the description is **back-filled from the app's stored `sus.json`** (`git_workflow.py:120-129`), which may be **stale**;
- the user clicked Build to make a *specific* change and is about to say what it is.

Auto-kicking a build there would risk clobbering intentional changes or nagging about a spec the app has outgrown. So existing-app sessions stay plain interactive, unchanged.

## New-vs-existing detection
Reuses the existing scaffold gate: absence of `sus.json` = brand-new app (an existing app's clone brings its own `sus.json` down). This is **restart-safe** — a recreated pod re-clones the now-committed scaffold, so `NEW_APP` reads 0 and we don't re-kick a build when a pod restarts mid-session.

## Safety
`APP_DESCRIPTION` is untrusted user input. It's passed via an **exported env var** and expanded by the *inner* shell as a single quoted argument (escaped `\$SUS_INITIAL_PROMPT`) — never spliced into the command string. Verified with a hostile description containing `"`, `$(...)`, backticks, `;`, and newlines: `claude` receives it as exactly one literal argument and nothing is evaluated as shell (no `/tmp/PWNED`).

## Also
Softens `build-pod/CLAUDE.md` so a resumed session treats the description as *background* about the app's original intent rather than a spec to enforce — don't assume divergence is a bug, wait for the user's direction.

## Verification
- `bash -n` clean; `shellcheck` clean.
- Branch matrix confirmed: existing-app → no seed; new-app-no-description → no seed; new-app + description → seeded.
- Injection test passes (single literal arg, no shell execution).

Not yet exercised live in a pod — worth a smoke test on a cluster before/after merge (create a new app with a description → confirm Claude starts building immediately; click Build on an existing app → confirm it waits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)